### PR TITLE
Fix issue #9: Add more items in map popup

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -102,6 +102,7 @@ const Map: React.FC<MapProps> = ({ data, filteredSpecies }) => {
                 Län: {feature.properties.county}<br />
                 Fångade arter: {renderCaughtSpecies(feature)}<br />
                 Vanligaste art: {feature.properties.vanlArt || 'Okänd'}<br />
+                Näst vanligaste art: {feature.properties.nästVanlArt || 'Okänd'}<br />
                 Senaste fiskeår: {feature.properties.senasteFiskeår || 'Okänt'}
               </div>
             </Tooltip>

--- a/src/components/__tests__/Map.test.tsx
+++ b/src/components/__tests__/Map.test.tsx
@@ -141,10 +141,25 @@ describe('Map', () => {
   });
 
   it('displays correct tooltip information', () => {
-    const features = [
-      createMockFeature('Test Lake', [18.0579, 59.3293], ['Gädda', 'Abborre'])
-    ];
-    const data = createMockData(features);
+    const feature: GeoJsonFeature = {
+      type: 'Feature' as const,
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [18.0579, 59.3293]
+      },
+      properties: {
+        name: 'Test Lake',
+        county: 'Test County',
+        location: 'Test Location',
+        maxDepth: 10,
+        area: 100,
+        elevation: 50,
+        catchedSpecies: ['Gädda', 'Abborre'],
+        vanlArt: 'Gädda',
+        nästVanlArt: 'Abborre'
+      }
+    };
+    const data = createMockData([feature]);
 
     render(<Map data={data} filteredSpecies={new Set()} />);
 
@@ -154,6 +169,8 @@ describe('Map', () => {
     expect(tooltip).toHaveTextContent('Area: 100 ha');
     expect(tooltip).toHaveTextContent('Test County');
     expect(tooltip).toHaveTextContent('Gädda, Abborre');
+    expect(tooltip).toHaveTextContent('Vanligaste art: Gädda');
+    expect(tooltip).toHaveTextContent('Näst vanligaste art: Abborre');
   });
 
   it('handles missing or null values in tooltip', () => {


### PR DESCRIPTION
This pull request fixes #9.

The issue has been successfully resolved based on the concrete changes made:

1. The code changes in Map.tsx directly add the requested "Näst vanligaste art" field to the hover popup, using the correct property name "nästVanlArt" from the lake data
2. The implementation includes proper fallback handling with "|| 'Okänd'" for cases where the data is missing
3. The test file was appropriately updated to verify the new functionality, including:
   - A test case with sample data containing the "nästVanlArt" property
   - Explicit verification that both "Vanligaste art" and "Näst vanligaste art" appear in the tooltip
   - The test is passing, confirming the functionality works as expected

The changes directly implement what was requested in the issue description - adding a new hover popup item showing the second most common species from the lake data. The implementation is complete, properly tested, and handles edge cases appropriately.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌