### PR TITLE
Fix issue #12: Add percentage to most common species

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -101,8 +101,8 @@ const Map: React.FC<MapProps> = ({ data, filteredSpecies }) => {
                   : 'Okänd'}<br />
                 Län: {feature.properties.county}<br />
                 Fångade arter: {renderCaughtSpecies(feature)}<br />
-                Vanligaste art: {feature.properties.vanlArt || 'Okänd'}<br />
-                Näst vanligaste art: {feature.properties.nästVanlArt || 'Okänd'}<br />
+                Vanligaste art: {feature.properties.vanlArt ? `${feature.properties.vanlArt} (${feature.properties.vanlArtWProc}%)` : 'Okänd'}<br />
+                Näst vanligaste art: {feature.properties.nästVanlArt ? `${feature.properties.nästVanlArt} (${feature.properties.nästVanlArtWProc}%)` : 'Okänd'}<br />
                 Senaste fiskeår: {feature.properties.senasteFiskeår || 'Okänt'}
               </div>
             </Tooltip>

--- a/src/components/__tests__/Map.test.tsx
+++ b/src/components/__tests__/Map.test.tsx
@@ -173,6 +173,36 @@ describe('Map', () => {
     expect(tooltip).toHaveTextContent('Näst vanligaste art: Abborre');
   });
 
+  it('displays species percentages in tooltip', () => {
+    const feature: GeoJsonFeature = {
+      type: 'Feature' as const,
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [18.0579, 59.3293]
+      },
+      properties: {
+        name: 'Test Lake',
+        county: 'Test County',
+        location: 'Test Location',
+        maxDepth: 10,
+        area: 100,
+        elevation: 50,
+        catchedSpecies: ['Gädda', 'Abborre'],
+        vanlArt: 'Gädda',
+        vanlArtWProc: 45,
+        nästVanlArt: 'Abborre',
+        nästVanlArtWProc: 30
+      }
+    };
+    const data = createMockData([feature]);
+
+    render(<Map data={data} filteredSpecies={new Set()} />);
+
+    const tooltip = screen.getByTestId('tooltip');
+    expect(tooltip).toHaveTextContent('Vanligaste art: Gädda (45%)');
+    expect(tooltip).toHaveTextContent('Näst vanligaste art: Abborre (30%)');
+  });
+
   it('handles missing or null values in tooltip', () => {
     const feature: GeoJsonFeature = {
       type: 'Feature' as const,


### PR DESCRIPTION
This pull request fixes #12.

The issue has been successfully resolved based on the following concrete changes and their impact:

1. The code changes in Map.tsx directly implement the requested feature by modifying the tooltip display format to include percentages:
- Changed `feature.properties.vanlArt || 'Okänd'` to `feature.properties.vanlArt ? ${feature.properties.vanlArt} (${feature.properties.vanlArtWProc}%)` : 'Okänd'`
- Made the same change for `nästVanlArt` using `nästVanlArtWProc`

2. The changes will transform the display from:
Original: "Vanligaste art: Abborre"
New: "Vanligaste art: Abborre (24%)"

3. The implementation:
- Correctly uses the specified percentage fields (vanlArtWProc and nästVanlArtWProc)
- Maintains proper error handling for unknown/missing values
- Preserves the existing functionality while adding the new feature

4. The new test case verifies that the percentages are correctly displayed (45% for Gädda and 30% for Abborre), demonstrating that the implementation works as intended.

The changes directly fulfill the requirements specified in the issue description, with proper implementation and verification through tests.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌