### PR TITLE
Fix issue #16: Fix issue in acceptance tests workflow

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -77,7 +77,7 @@ jobs:
           headed: false
       
       - name: Upload screenshots if tests fail
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots


### PR DESCRIPTION
This pull request fixes #16.

The issue has been successfully resolved. The specific change made was updating the version of the actions/upload-artifact GitHub Action from v3 to v4 in the acceptance-tests.yml workflow file. This directly addresses the stated issue of using a deprecated component.

The change is straightforward and complete:
1. The exact line that needed updating was identified
2. The version number was changed from v3 to v4
3. No other changes were needed since this was purely a version upgrade

The upload-artifact action is used to store screenshots when tests fail, and the v4 upgrade provides the same core functionality with newer features and security updates. Since this is a configuration change to the CI pipeline rather than application code, no additional testing is required - the action will either work or fail immediately when the workflow runs.

The change fully resolves the deprecation warning while maintaining the same functionality in the CI pipeline.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌