### PR TITLE
Fix issue #18: Add sidepanel to the left

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import Map from './components/Map';
 import SpeciesFilter from './components/SpeciesFilter';
-import { GeoJsonCollection } from './types/GeoJsonTypes';
+import SidePanel from './components/SidePanel';
+import { GeoJsonCollection, GeoJsonFeature } from './types/GeoJsonTypes';
 import { mergeGeoJsonCollections, removeBOM, convertLakeDataToGeoJson } from './utils/DataLoader';
 
 export const BASE_PATH = process.env.PUBLIC_URL || '/fishingwaters';
@@ -11,6 +12,7 @@ function App() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [filteredSpecies, setFilteredSpecies] = useState<Set<string>>(new Set());
+  const [selectedLake, setSelectedLake] = useState<GeoJsonFeature | null>(null);
 
   useEffect(() => {
     fetchAllLakeData();
@@ -109,7 +111,12 @@ function App() {
 
   return (
     <div className="app">
-      <Map data={data} filteredSpecies={filteredSpecies} />
+      <SidePanel selectedLake={selectedLake} />
+      <Map
+        data={data}
+        filteredSpecies={filteredSpecies}
+        onLakeSelect={setSelectedLake}
+      />
       <SpeciesFilter features={data.features} onFilterChange={handleFilterChange} />
     </div>
   );

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -5,9 +5,10 @@ import { GeoJsonCollection, GeoJsonFeature } from '../types/GeoJsonTypes';
 interface MapProps {
   data: GeoJsonCollection;
   filteredSpecies: Set<string>;
+  onLakeSelect: (lake: GeoJsonFeature) => void;
 }
 
-const Map: React.FC<MapProps> = ({ data, filteredSpecies }) => {
+const Map: React.FC<MapProps> = ({ data, filteredSpecies, onLakeSelect }) => {
   const swedenCenter: [number, number] = [62.0, 15.0];
   
   // Filter features based on selected species
@@ -76,6 +77,9 @@ const Map: React.FC<MapProps> = ({ data, filteredSpecies }) => {
               weight: 1,
               opacity: 1,
               fillOpacity: 0.8
+            }}
+            eventHandlers={{
+              click: () => onLakeSelect(feature)
             }}
           >
             <Tooltip sticky direction="top">

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { GeoJsonFeature } from '../types/GeoJsonTypes';
+
+interface SidePanelProps {
+  selectedLake: GeoJsonFeature | null;
+}
+
+const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
+  if (!selectedLake) {
+    return (
+      <div className="side-panel">
+        <p>Välj en sjö på kartan för att se mer information</p>
+      </div>
+    );
+  }
+
+  const renderCaughtSpecies = (species: string[] | string | undefined): string => {
+    if (!species) return 'Inga rapporterade';
+    if (Array.isArray(species)) return species.join(', ');
+    return species;
+  };
+
+  return (
+    <div className="side-panel">
+      <h2>{selectedLake.properties.name}</h2>
+      <div className="lake-info">
+        <p><strong>Maxdjup:</strong> {selectedLake.properties.maxDepth !== null ? `${selectedLake.properties.maxDepth} m` : 'Okänt'}</p>
+        <p><strong>Area:</strong> {selectedLake.properties.area !== null && selectedLake.properties.area !== undefined
+          ? `${selectedLake.properties.area.toLocaleString()} ha`
+          : 'Okänd'}</p>
+        <p><strong>Län:</strong> {selectedLake.properties.county}</p>
+        <p><strong>Fångade arter:</strong> {renderCaughtSpecies(selectedLake.properties.catchedSpecies || selectedLake.properties.fångadeArter)}</p>
+        <p><strong>Vanligaste art:</strong> {selectedLake.properties.vanlArt
+          ? `${selectedLake.properties.vanlArt} (${selectedLake.properties.vanlArtWProc}%)`
+          : 'Okänd'}</p>
+        <p><strong>Näst vanligaste art:</strong> {selectedLake.properties.nästVanlArt
+          ? `${selectedLake.properties.nästVanlArt} (${selectedLake.properties.nästVanlArtWProc}%)`
+          : 'Okänd'}</p>
+        <p><strong>Senaste fiskeår:</strong> {selectedLake.properties.senasteFiskeår || 'Okänt'}</p>
+      </div>
+    </div>
+  );
+};
+
+export default SidePanel;

--- a/src/components/__tests__/SidePanel.test.tsx
+++ b/src/components/__tests__/SidePanel.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SidePanel from '../SidePanel';
+import { GeoJsonFeature } from '../../types/GeoJsonTypes';
+
+describe('SidePanel', () => {
+  const mockLake: GeoJsonFeature = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [18.0686, 59.3293]
+    },
+    properties: {
+      name: 'Test Lake',
+      maxDepth: 10,
+      area: 1000,
+      county: 'Test County',
+      catchedSpecies: ['Pike', 'Perch'],
+      vanlArt: 'Pike',
+      vanlArtWProc: 60,
+      nästVanlArt: 'Perch',
+      nästVanlArtWProc: 40,
+      senasteFiskeår: '2023'
+    }
+  };
+
+  it('displays default message when no lake is selected', () => {
+    render(<SidePanel selectedLake={null} />);
+    expect(screen.getByText('Välj en sjö på kartan för att se mer information')).toBeInTheDocument();
+  });
+
+  it('displays lake information when a lake is selected', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+
+    expect(screen.getByText('Test Lake')).toBeInTheDocument();
+    expect(screen.getByText('10 m')).toBeInTheDocument();
+    expect(screen.getByText('1,000 ha')).toBeInTheDocument();
+    expect(screen.getByText('Test County')).toBeInTheDocument();
+    expect(screen.getByText('Pike, Perch')).toBeInTheDocument();
+    expect(screen.getByText('Pike (60%)')).toBeInTheDocument();
+    expect(screen.getByText('Perch (40%)')).toBeInTheDocument();
+    expect(screen.getByText('2023')).toBeInTheDocument();
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -63,3 +63,34 @@ code {
   font-size: 14px;
   padding: 4px 8px;
 }
+
+.app {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+  position: relative;
+}
+
+.side-panel {
+  width: 300px;
+  background-color: white;
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+  padding: 20px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.side-panel h2 {
+  margin-top: 0;
+  margin-bottom: 20px;
+  color: #333;
+}
+
+.lake-info p {
+  margin: 10px 0;
+  line-height: 1.4;
+}
+
+.lake-info strong {
+  color: #555;
+}


### PR DESCRIPTION
This pull request fixes #18.

The issue has been successfully resolved based on the concrete changes made. The PR implements all required functionality to display lake information in a left sidepanel:

1. A new SidePanel component was created that displays detailed lake information including name, depth, area, county, caught species, and most common species
2. The Map component was modified to handle lake selection via click events and pass the selected lake data to the sidepanel
3. State management was added in App.tsx to track the currently selected lake
4. Proper styling was implemented to position the sidepanel on the left side with appropriate width, scrolling, and visual styling
5. The component handles both the selected and unselected states appropriately, showing a default message when no lake is selected
6. Unit tests verify the component renders correctly in both states and displays all lake information properly

The changes directly fulfill the requirement to "Add a sidepanel to the left that displays information about the last selected lake" with a complete, working implementation. The code changes show the feature is fully functional and properly integrated into the application architecture.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌