### PR TITLE
Fix issue #22: Add driving directions

### DIFF
--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -86,4 +86,31 @@ describe('Fishing Waters App Acceptance Tests', () => {
     
     checkWithRetry();
   });
+
+  it('shows directions interface when a lake is selected', () => {
+    // Wait for map data to load
+    cy.get('.leaflet-overlay-pane svg path', { timeout: 20000 }).should('exist');
+
+    // Click on a lake marker (first one we find)
+    cy.get('.leaflet-overlay-pane svg path').first().click();
+
+    // Verify the side panel shows lake info
+    cy.get('.side-panel h2').should('exist');
+
+    // Verify directions interface is shown
+    cy.get('.directions-container').should('exist');
+    cy.get('.directions-container h3').should('contain', 'Vägbeskrivning');
+    cy.get('label[for="start-location"]').should('contain', 'Din plats:');
+    cy.get('#start-location').should('exist');
+    cy.get('.directions-button').should('contain', 'Hämta vägbeskrivning');
+
+    // Verify button is initially disabled
+    cy.get('.directions-button').should('be.disabled');
+
+    // Enter a location
+    cy.get('#start-location').type('Stockholm');
+
+    // Verify button is now enabled
+    cy.get('.directions-button').should('not.be.disabled');
+  });
 });

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GeoJsonFeature } from '../types/GeoJsonTypes';
 
 interface SidePanelProps {
@@ -6,6 +6,8 @@ interface SidePanelProps {
 }
 
 const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
+  const [startLocation, setStartLocation] = useState<string>('');
+
   if (!selectedLake) {
     return (
       <div className="side-panel">
@@ -18,6 +20,25 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
     if (!species) return 'Inga rapporterade';
     if (Array.isArray(species)) return species.join(', ');
     return species;
+  };
+
+  const getDirectionsUrl = () => {
+    if (!selectedLake || !startLocation.trim()) return '';
+
+    const { coordinates } = selectedLake.geometry;
+    const destination = `${coordinates[1]},${coordinates[0]}`; // [lat, lng] for Google Maps
+    const encodedStart = encodeURIComponent(startLocation);
+    const encodedDestination = encodeURIComponent(destination);
+    const encodedLakeName = encodeURIComponent(selectedLake.properties.name);
+
+    return `https://www.google.com/maps/dir/?api=1&origin=${encodedStart}&destination=${encodedDestination}&destination_place_id=${encodedLakeName}`;
+  };
+
+  const handleGetDirections = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (startLocation.trim()) {
+      window.open(getDirectionsUrl(), '_blank');
+    }
   };
 
   return (
@@ -37,6 +58,30 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
           ? `${selectedLake.properties.nästVanlArt} (${selectedLake.properties.nästVanlArtWProc}%)`
           : 'Okänd'}</p>
         <p><strong>Senaste fiskeår:</strong> {selectedLake.properties.senasteFiskeår || 'Okänt'}</p>
+      </div>
+
+      <div className="directions-container">
+        <h3>Vägbeskrivning</h3>
+        <form onSubmit={handleGetDirections}>
+          <div className="directions-input">
+            <label htmlFor="start-location">Din plats:</label>
+            <input
+              id="start-location"
+              type="text"
+              value={startLocation}
+              onChange={(e) => setStartLocation(e.target.value)}
+              placeholder="Ange din startplats"
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            className="directions-button"
+            disabled={!startLocation.trim()}
+          >
+            Hämta vägbeskrivning
+          </button>
+        </form>
       </div>
     </div>
   );

--- a/src/components/__tests__/SidePanel.test.tsx
+++ b/src/components/__tests__/SidePanel.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import SidePanel from '../SidePanel';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
+
+// Mock window.open
+const mockOpen = jest.fn();
+window.open = mockOpen;
 
 describe('SidePanel', () => {
   const mockLake: GeoJsonFeature = {
@@ -24,6 +28,10 @@ describe('SidePanel', () => {
     }
   };
 
+  beforeEach(() => {
+    mockOpen.mockClear();
+  });
+
   it('displays default message when no lake is selected', () => {
     render(<SidePanel selectedLake={null} />);
     expect(screen.getByText('Välj en sjö på kartan för att se mer information')).toBeInTheDocument();
@@ -40,5 +48,50 @@ describe('SidePanel', () => {
     expect(screen.getByText('Pike (60%)')).toBeInTheDocument();
     expect(screen.getByText('Perch (40%)')).toBeInTheDocument();
     expect(screen.getByText('2023')).toBeInTheDocument();
+  });
+
+  it('displays the directions form when a lake is selected', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+
+    expect(screen.getByText('Vägbeskrivning')).toBeInTheDocument();
+    expect(screen.getByLabelText('Din plats:')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Ange din startplats')).toBeInTheDocument();
+    expect(screen.getByText('Hämta vägbeskrivning')).toBeInTheDocument();
+  });
+
+  it('enables the directions button when a location is entered', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+
+    const button = screen.getByText('Hämta vägbeskrivning');
+    const input = screen.getByLabelText('Din plats:');
+
+    // Button should be disabled initially
+    expect(button).toBeDisabled();
+
+    // Enter a location
+    fireEvent.change(input, { target: { value: 'Stockholm' } });
+
+    // Button should be enabled
+    expect(button).not.toBeDisabled();
+  });
+
+  it('opens Google Maps with correct URL when form is submitted', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+
+    const button = screen.getByText('Hämta vägbeskrivning');
+    const input = screen.getByLabelText('Din plats:');
+
+    // Enter a location
+    fireEvent.change(input, { target: { value: 'Stockholm' } });
+
+    // Submit the form
+    fireEvent.click(button);
+
+    // Check that window.open was called with the correct URL
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+    expect(mockOpen).toHaveBeenCalledWith(
+      expect.stringContaining('https://www.google.com/maps/dir/?api=1&origin=Stockholm&destination=59.3293%2C18.0686'),
+      '_blank'
+    );
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -94,3 +94,56 @@ code {
 .lake-info strong {
   color: #555;
 }
+
+.directions-container {
+  margin-top: 20px;
+  padding-top: 15px;
+  border-top: 1px solid #eee;
+}
+
+.directions-container h3 {
+  margin-top: 0;
+  margin-bottom: 15px;
+  color: #333;
+  font-size: 1.2em;
+}
+
+.directions-input {
+  margin-bottom: 15px;
+}
+
+.directions-input label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: 500;
+  color: #555;
+}
+
+.directions-input input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.directions-button {
+  background-color: #3388ff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  width: 100%;
+}
+
+.directions-button:hover {
+  background-color: #2377e8;
+}
+
+.directions-button:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
This pull request fixes #22.

The issue has been successfully resolved. The PR adds a directions interface at the bottom of the side panel that allows users to get directions from their location to a selected lake. The implementation includes:

1. A new "Vägbeskrivning" (Directions) section in the SidePanel component with:
   - An input field labeled "Din plats:" (Your location) where users can enter their current location
   - A "Hämta vägbeskrivning" (Get directions) button that opens Google Maps in a new tab with the route

2. The functionality is complete:
   - The button is disabled until a location is entered
   - When submitted, it generates a Google Maps URL with the user's location as origin and the lake's coordinates as destination
   - The form opens Google Maps in a new tab when submitted

3. Proper styling has been added to the CSS to make the interface visually consistent with the rest of the application

4. Comprehensive tests have been added to verify the functionality:
   - Unit tests for the SidePanel component
   - End-to-end tests using Cypress to verify the interface appears when a lake is selected

The implementation fully addresses the requirements specified in the issue description.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌