### PR TITLE
Add minimize button to the right filter panel

### DIFF
--- a/.claude/commands/fix-all-open-issues.md
+++ b/.claude/commands/fix-all-open-issues.md
@@ -5,4 +5,5 @@ Find and fix all open issues # that you can find in github issues using the gh c
 4. Implement a solution that addresses the root cause 
 5. Add appropriate tests and run all tests 
 6. Prepare a concise PR description 
-7. Create a PR and push to github 8. Change back to main branch
+7. Create a PR and push to github 
+8. Change back to main branch

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,1 +1,9 @@
-Find and fix issue # that you can find in github issues using the gh command. Follow these steps: 1. Understand the issue described in the ticket 2. Create a new branch before working on the issue 3. Locate the relevant code in our codebase 4. Implement a solution that addresses the root cause 5. Add appropriate tests and run all tests 6. Prepare a concise PR description 7. Create a PR and push to github 8. Change back to main branch
+Find and fix issue # that you can find in github issues using the gh command. Follow these steps: 
+1. Understand the issue described in the ticket 
+2. Create a new branch before working on the issue 
+3. Locate the relevant code in our codebase 
+4. Implement a solution that addresses the root cause 
+5. Add appropriate tests and run all tests 
+6. Prepare a concise PR description 
+7. Create a PR and push to github 
+8. Change back to main branch

--- a/.claude/commands/list-issues.md
+++ b/.claude/commands/list-issues.md
@@ -1,1 +1,2 @@
-List all issues # that you can find in github issues using the gh command. Follow these steps: 1. Get all open issues
+List all issues # that you can find in github issues using the gh command. Follow these steps: 
+1. Get all open issues

--- a/src/components/SpeciesFilter.tsx
+++ b/src/components/SpeciesFilter.tsx
@@ -9,8 +9,11 @@ import {
   Checkbox,
   Stack,
   Divider,
-  Box
+  Box,
+  IconButton
 } from '@mui/material';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import { styled } from '@mui/material/styles';
 
 interface SpeciesFilterProps {
@@ -28,12 +31,26 @@ const StyledFilterPanel = styled(Paper)(({ theme }) => ({
   overflow: 'auto',
   width: 250,
   boxShadow: theme.shadows[3],
-  borderRadius: theme.shape.borderRadius
+  borderRadius: theme.shape.borderRadius,
+  transition: 'transform 0.3s ease-in-out'
+}));
+
+const MinimizedPanel = styled(Paper)(({ theme }) => ({
+  position: 'absolute',
+  top: theme.spacing(2),
+  right: theme.spacing(2),
+  padding: theme.spacing(1),
+  zIndex: 1000,
+  boxShadow: theme.shadows[3],
+  borderRadius: theme.shape.borderRadius,
+  display: 'flex',
+  alignItems: 'center'
 }));
 
 const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange }) => {
   const [uniqueSpecies, setUniqueSpecies] = useState<string[]>([]);
   const [selectedSpecies, setSelectedSpecies] = useState<Set<string>>(new Set());
+  const [minimized, setMinimized] = useState<boolean>(false);
 
   useEffect(() => {
     const speciesSet = new Set<string>();
@@ -81,11 +98,44 @@ const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange 
     onFilterChange(new Set());
   };
 
+  const toggleMinimized = () => {
+    setMinimized(!minimized);
+  };
+
+  if (minimized) {
+    return (
+      <MinimizedPanel className="filter-panel-minimized">
+        <IconButton 
+          onClick={toggleMinimized}
+          aria-label="Expand filter panel"
+          title="Visa filterpanel"
+          color="primary"
+        >
+          <ChevronLeftIcon />
+        </IconButton>
+        <Typography variant="subtitle2" color="primary" sx={{ ml: 1 }}>
+          {selectedSpecies.size > 0 ? `${selectedSpecies.size} arter valda` : 'Filter'}
+        </Typography>
+      </MinimizedPanel>
+    );
+  }
+
   return (
     <StyledFilterPanel className="filter-panel">
-      <Typography variant="subtitle1" color="primary" fontWeight="medium" gutterBottom className="filter-header">
-        Filtrera efter arter
-      </Typography>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+        <Typography variant="subtitle1" color="primary" fontWeight="medium" className="filter-header">
+          Filtrera efter arter
+        </Typography>
+        <IconButton 
+          onClick={toggleMinimized}
+          aria-label="Minimize filter panel"
+          title="Minimera filterpanel"
+          size="small"
+          color="primary"
+        >
+          <ChevronRightIcon />
+        </IconButton>
+      </Box>
       
       <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
         <Button 

--- a/src/components/__tests__/SpeciesFilter.test.tsx
+++ b/src/components/__tests__/SpeciesFilter.test.tsx
@@ -4,6 +4,10 @@ import '@testing-library/jest-dom';
 import SpeciesFilter from '../SpeciesFilter';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
 
+// Mock the MUI icons
+jest.mock('@mui/icons-material/ChevronRight', () => () => <div data-testid="chevron-right-icon" />);
+jest.mock('@mui/icons-material/ChevronLeft', () => () => <div data-testid="chevron-left-icon" />);
+
 describe('SpeciesFilter', () => {
   const mockOnFilterChange = jest.fn();
 
@@ -174,5 +178,66 @@ describe('SpeciesFilter', () => {
     
     const checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes).toHaveLength(0);
+  });
+
+  it('renders a minimize button in the expanded state', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    const minimizeButton = screen.getByTitle('Minimera filterpanel');
+    expect(minimizeButton).toBeInTheDocument();
+  });
+
+  it('minimizes the panel when minimize button is clicked', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    const minimizeButton = screen.getByTitle('Minimera filterpanel');
+    fireEvent.click(minimizeButton);
+    
+    // Panel should be minimized, expand button should be visible
+    expect(screen.queryByText('Filtrera efter arter')).not.toBeInTheDocument();
+    const expandButton = screen.getByTitle('Visa filterpanel');
+    expect(expandButton).toBeInTheDocument();
+    expect(screen.getByText('Filter')).toBeInTheDocument();
+  });
+
+  it('expands the panel when expand button is clicked', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    // First minimize
+    const minimizeButton = screen.getByTitle('Minimera filterpanel');
+    fireEvent.click(minimizeButton);
+    
+    // Then expand
+    const expandButton = screen.getByTitle('Visa filterpanel');
+    fireEvent.click(expandButton);
+    
+    // Panel should be expanded again
+    expect(screen.getByText('Filtrera efter arter')).toBeInTheDocument();
+    expect(screen.queryByTitle('Visa filterpanel')).not.toBeInTheDocument();
+  });
+
+  it('shows the number of selected species in minimized state', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre', 'Gös'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    // Select two species
+    const gaddaCheckbox = screen.getByLabelText('Gädda') as HTMLInputElement;
+    const abborreCheckbox = screen.getByLabelText('Abborre') as HTMLInputElement;
+    fireEvent.click(gaddaCheckbox);
+    fireEvent.click(abborreCheckbox);
+    
+    // Minimize the panel
+    const minimizeButton = screen.getByTitle('Minimera filterpanel');
+    fireEvent.click(minimizeButton);
+    
+    // Check that the minimized panel shows the correct count
+    expect(screen.getByText('2 arter valda')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Added minimize button to the species filter panel with a clean UI
- Implemented a minimized state that shows a count of active filters
- Added expand button to return to the full panel view
- Added smooth transitions for a polished user experience
- Comprehensive test coverage for all new functionality

## Test plan
- Run all tests to verify functionality works as expected
- Manually test minimizing and maximizing the panel
- Verify that the filter count in minimized state updates when filters change

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)