### PR TITLE
Change map markers to red when filters are applied

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -64,7 +64,7 @@ const Map: React.FC<MapProps> = ({ data, filteredSpecies, onLakeSelect }) => {
         // Leaflet uses [lat, lng] whereas GeoJSON uses [lng, lat]
         const position: [number, number] = [coordinates[1], coordinates[0]]; 
         
-        const fillColor = '#3388ff';
+        const fillColor = filteredSpecies.size > 0 ? '#ff3333' : '#3388ff';
         
         return (
           <CircleMarker 


### PR DESCRIPTION
## Summary
- Changes map markers from blue to red when any filter is active
- Provides a clear visual indication that the map is showing filtered results
- Implemented by adding a conditional color based on filteredSpecies.size

## Test plan
- Apply a species filter and verify markers turn red
- Clear all filters and verify markers return to blue

Fixes #33

🤖 Generated with [Claude Code](https://claude.ai/code)