### PR TITLE
Add weather information to lake details panel

### DIFF
--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -7,9 +7,11 @@ import {
   ListItem, 
   ListItemText, 
   Divider,
-  Box
+  Box,
+  CircularProgress
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { useWeatherData } from '../utils/weatherService';
 
 interface SidePanelProps {
   selectedLake: GeoJsonFeature | null;
@@ -44,6 +46,14 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
     return species;
   };
 
+  // Extract coordinates from the selected lake's geometry
+  const { coordinates } = selectedLake.geometry;
+  // GeoJSON uses [longitude, latitude] format, but our weather API needs [latitude, longitude]
+  const [longitude, latitude] = coordinates;
+  
+  // Fetch weather data for the lake coordinates
+  const { temperature, windSpeed, weatherDescription, isLoading, error } = useWeatherData(latitude, longitude);
+
   return (
     <StyledSidePanel>
       <Typography variant="h5" component="h2" gutterBottom color="primary">
@@ -51,6 +61,36 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
       </Typography>
       <Divider sx={{ mb: 2 }} />
       <List disablePadding>
+        {/* Weather section */}
+        <ListItem>
+          <Box width="100%">
+            <Typography variant="subtitle1" color="primary" gutterBottom>
+              Aktuellt väder
+            </Typography>
+            
+            {isLoading ? (
+              <Box display="flex" alignItems="center" mt={1}>
+                <CircularProgress size={20} sx={{ mr: 1 }} />
+                <Typography variant="body2">Laddar väderdata...</Typography>
+              </Box>
+            ) : error ? (
+              <Typography variant="body2" color="error">
+                Kunde inte ladda väderdata: {error}
+              </Typography>
+            ) : (
+              <Box sx={{ mt: 1 }}>
+                <Typography variant="body2">
+                  {weatherDescription}, {temperature}°C
+                </Typography>
+                <Typography variant="body2">
+                  Vindhastighet: {windSpeed} m/s
+                </Typography>
+              </Box>
+            )}
+          </Box>
+        </ListItem>
+        <Divider sx={{ my: 1 }} />
+        
         <ListItem sx={{ py: 1 }}>
           <ListItemText 
             primary="Maxdjup" 

--- a/src/components/__tests__/SidePanel.test.tsx
+++ b/src/components/__tests__/SidePanel.test.tsx
@@ -3,6 +3,18 @@ import { render, screen } from '@testing-library/react';
 import SidePanel from '../SidePanel';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
 
+// Mock the weather service hook
+jest.mock('../../utils/weatherService', () => ({
+  useWeatherData: () => ({
+    temperature: 15,
+    windSpeed: 5,
+    weatherCode: 0,
+    weatherDescription: 'Klar himmel',
+    isLoading: false,
+    error: null
+  })
+}));
+
 describe('SidePanel', () => {
   const mockLake: GeoJsonFeature = {
     type: 'Feature',
@@ -40,5 +52,13 @@ describe('SidePanel', () => {
     expect(screen.getByText('Pike (60%)')).toBeInTheDocument();
     expect(screen.getByText('Perch (40%)')).toBeInTheDocument();
     expect(screen.getByText('2023')).toBeInTheDocument();
+  });
+  
+  it('displays weather information section', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+    
+    expect(screen.getByText('Aktuellt väder')).toBeInTheDocument();
+    expect(screen.getByText('Klar himmel, 15°C')).toBeInTheDocument();
+    expect(screen.getByText('Vindhastighet: 5 m/s')).toBeInTheDocument();
   });
 });

--- a/src/utils/__tests__/weatherService.test.ts
+++ b/src/utils/__tests__/weatherService.test.ts
@@ -1,0 +1,15 @@
+import { weatherCodeToDescription } from '../weatherService';
+
+describe('weatherService', () => {
+  describe('weatherCodeToDescription', () => {
+    it('should return the correct weather description for a given code', () => {
+      expect(weatherCodeToDescription(0)).toBe('Klar himmel');
+      expect(weatherCodeToDescription(61)).toBe('Lätt regn');
+      expect(weatherCodeToDescription(95)).toBe('Åskväder');
+    });
+
+    it('should return "Okänt väder" for unknown weather codes', () => {
+      expect(weatherCodeToDescription(999)).toBe('Okänt väder');
+    });
+  });
+});

--- a/src/utils/weatherService.ts
+++ b/src/utils/weatherService.ts
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react';
+
+interface WeatherData {
+  temperature: number;
+  windSpeed: number;
+  weatherCode: number;
+  weatherDescription: string;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const weatherCodeToDescription = (code: number): string => {
+  // WMO Weather interpretation codes (WW)
+  // https://open-meteo.com/en/docs
+  const weatherCodes: Record<number, string> = {
+    0: 'Klar himmel',
+    1: 'Mestadels klar',
+    2: 'Delvis molnigt',
+    3: 'Molnigt',
+    45: 'Dimma',
+    48: 'Rimfrost',
+    51: 'Lätt duggregn',
+    53: 'Måttligt duggregn',
+    55: 'Kraftigt duggregn',
+    56: 'Lätt underkylt duggregn',
+    57: 'Kraftigt underkylt duggregn',
+    61: 'Lätt regn',
+    63: 'Måttligt regn',
+    65: 'Kraftigt regn',
+    66: 'Lätt underkylt regn',
+    67: 'Kraftigt underkylt regn',
+    71: 'Lätt snöfall',
+    73: 'Måttligt snöfall',
+    75: 'Kraftigt snöfall',
+    77: 'Snökorn',
+    80: 'Lätta regnskurar',
+    81: 'Måttliga regnskurar',
+    82: 'Kraftiga regnskurar',
+    85: 'Lätta snöbyar',
+    86: 'Kraftiga snöbyar',
+    95: 'Åskväder',
+    96: 'Åskväder med lätt hagel',
+    99: 'Åskväder med kraftigt hagel',
+  };
+
+  return weatherCodes[code] || 'Okänt väder';
+};
+
+export const useWeatherData = (latitude: number, longitude: number): WeatherData => {
+  const [weatherData, setWeatherData] = useState<WeatherData>({
+    temperature: 0,
+    windSpeed: 0,
+    weatherCode: 0,
+    weatherDescription: '',
+    isLoading: true,
+    error: null
+  });
+
+  useEffect(() => {
+    const fetchWeatherData = async () => {
+      if (!latitude || !longitude) {
+        setWeatherData(prevState => ({
+          ...prevState,
+          isLoading: false,
+          error: 'Ogiltiga koordinater'
+        }));
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,weather_code,wind_speed_10m&timezone=auto`
+        );
+
+        if (!response.ok) {
+          throw new Error(`Väderdata kunde inte hämtas: ${response.status}`);
+        }
+
+        const data = await response.json();
+        
+        if (data && data.current) {
+          const weatherCode = data.current.weather_code;
+          
+          setWeatherData({
+            temperature: data.current.temperature_2m,
+            windSpeed: data.current.wind_speed_10m,
+            weatherCode,
+            weatherDescription: weatherCodeToDescription(weatherCode),
+            isLoading: false,
+            error: null
+          });
+        } else {
+          throw new Error('Ogiltig väderdata från API');
+        }
+      } catch (error) {
+        setWeatherData(prevState => ({
+          ...prevState,
+          isLoading: false,
+          error: error instanceof Error ? error.message : 'Ett okänt fel uppstod'
+        }));
+      }
+    };
+
+    setWeatherData(prevState => ({ ...prevState, isLoading: true }));
+    fetchWeatherData();
+  }, [latitude, longitude]);
+
+  return weatherData;
+};


### PR DESCRIPTION
## Summary
- Adds current weather information to the lake details panel
- Shows temperature, weather conditions, and wind speed for the selected lake
- Uses Open-Meteo API which is free and does not require an API key
- Includes loading state and error handling

## Technical Implementation
- Created a new weatherService.ts utility with a React hook for fetching weather data
- Added weather information section to the lake details panel
- Implemented proper loading states and error handling
- Added appropriate tests

## Test plan
- Select different lakes and verify weather information displays correctly
- Check that the weather information updates when selecting different lakes
- Test error handling by temporarily modifying coordinates

Fixes #30

🤖 Generated with [Claude Code](https://claude.ai/code)