### PR TITLE
Add driving directions using Google Maps

### DIFF
--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -7,8 +7,10 @@ import {
   ListItem, 
   ListItemText, 
   Divider,
-  Box
+  Box,
+  Button
 } from '@mui/material';
+import DirectionsIcon from '@mui/icons-material/Directions';
 import { styled } from '@mui/material/styles';
 
 interface SidePanelProps {
@@ -43,12 +45,41 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
     if (Array.isArray(species)) return species.join(', ');
     return species;
   };
+  
+  // Generate Google Maps directions URL
+  const getDirectionsUrl = (): string => {
+    const { coordinates } = selectedLake.geometry;
+    // GeoJSON uses [longitude, latitude] format, but Google Maps uses latitude,longitude
+    const [longitude, latitude] = coordinates;
+    const destination = `${latitude},${longitude}`;
+    const lakeName = encodeURIComponent(selectedLake.properties.name);
+    
+    // Create URL with destination coordinates and lake name as a parameter
+    return `https://www.google.com/maps/dir/?api=1&destination=${destination}&destination_place_id=${lakeName}`;
+  };
+  
+  // Open Google Maps in a new tab
+  const openDirections = () => {
+    window.open(getDirectionsUrl(), '_blank', 'noopener,noreferrer');
+  };
 
   return (
     <StyledSidePanel>
-      <Typography variant="h5" component="h2" gutterBottom color="primary">
-        {selectedLake.properties.name}
-      </Typography>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+        <Typography variant="h5" component="h2" color="primary">
+          {selectedLake.properties.name}
+        </Typography>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          startIcon={<DirectionsIcon />}
+          onClick={openDirections}
+          title="Öppna vägbeskrivning i Google Maps"
+        >
+          Vägbeskrivning
+        </Button>
+      </Box>
       <Divider sx={{ mb: 2 }} />
       <List disablePadding>
         <ListItem sx={{ py: 1 }}>

--- a/src/components/__tests__/SidePanel.test.tsx
+++ b/src/components/__tests__/SidePanel.test.tsx
@@ -41,4 +41,28 @@ describe('SidePanel', () => {
     expect(screen.getByText('Perch (40%)')).toBeInTheDocument();
     expect(screen.getByText('2023')).toBeInTheDocument();
   });
+  
+  it('displays the directions button', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+    expect(screen.getByText('Vägbeskrivning')).toBeInTheDocument();
+  });
+  
+  it('has a button that opens Google Maps directions', () => {
+    // Mock window.open
+    const windowOpenMock = jest.fn();
+    Object.defineProperty(window, 'open', {
+      value: windowOpenMock,
+      writable: true
+    });
+    
+    render(<SidePanel selectedLake={mockLake} />);
+    
+    // Click the directions button
+    screen.getByText('Vägbeskrivning').click();
+    
+    // Check if window.open was called with the correct URL
+    expect(windowOpenMock).toHaveBeenCalledTimes(1);
+    expect(windowOpenMock.mock.calls[0][0]).toContain('https://www.google.com/maps/dir/?api=1&destination=59.3293,18.0686');
+    expect(windowOpenMock.mock.calls[0][1]).toBe('_blank');
+  });
 });

--- a/src/utils/__tests__/weatherService.test.ts
+++ b/src/utils/__tests__/weatherService.test.ts
@@ -1,0 +1,15 @@
+import { weatherCodeToDescription } from '../weatherService';
+
+describe('weatherService', () => {
+  describe('weatherCodeToDescription', () => {
+    it('should return the correct weather description for a given code', () => {
+      expect(weatherCodeToDescription(0)).toBe('Klar himmel');
+      expect(weatherCodeToDescription(61)).toBe('Lätt regn');
+      expect(weatherCodeToDescription(95)).toBe('Åskväder');
+    });
+
+    it('should return "Okänt väder" for unknown weather codes', () => {
+      expect(weatherCodeToDescription(999)).toBe('Okänt väder');
+    });
+  });
+});

--- a/src/utils/weatherService.ts
+++ b/src/utils/weatherService.ts
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react';
+
+interface WeatherData {
+  temperature: number;
+  windSpeed: number;
+  weatherCode: number;
+  weatherDescription: string;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export const weatherCodeToDescription = (code: number): string => {
+  // WMO Weather interpretation codes (WW)
+  // https://open-meteo.com/en/docs
+  const weatherCodes: Record<number, string> = {
+    0: 'Klar himmel',
+    1: 'Mestadels klar',
+    2: 'Delvis molnigt',
+    3: 'Molnigt',
+    45: 'Dimma',
+    48: 'Rimfrost',
+    51: 'Lätt duggregn',
+    53: 'Måttligt duggregn',
+    55: 'Kraftigt duggregn',
+    56: 'Lätt underkylt duggregn',
+    57: 'Kraftigt underkylt duggregn',
+    61: 'Lätt regn',
+    63: 'Måttligt regn',
+    65: 'Kraftigt regn',
+    66: 'Lätt underkylt regn',
+    67: 'Kraftigt underkylt regn',
+    71: 'Lätt snöfall',
+    73: 'Måttligt snöfall',
+    75: 'Kraftigt snöfall',
+    77: 'Snökorn',
+    80: 'Lätta regnskurar',
+    81: 'Måttliga regnskurar',
+    82: 'Kraftiga regnskurar',
+    85: 'Lätta snöbyar',
+    86: 'Kraftiga snöbyar',
+    95: 'Åskväder',
+    96: 'Åskväder med lätt hagel',
+    99: 'Åskväder med kraftigt hagel',
+  };
+
+  return weatherCodes[code] || 'Okänt väder';
+};
+
+export const useWeatherData = (latitude: number, longitude: number): WeatherData => {
+  const [weatherData, setWeatherData] = useState<WeatherData>({
+    temperature: 0,
+    windSpeed: 0,
+    weatherCode: 0,
+    weatherDescription: '',
+    isLoading: true,
+    error: null
+  });
+
+  useEffect(() => {
+    const fetchWeatherData = async () => {
+      if (!latitude || !longitude) {
+        setWeatherData(prevState => ({
+          ...prevState,
+          isLoading: false,
+          error: 'Ogiltiga koordinater'
+        }));
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current=temperature_2m,weather_code,wind_speed_10m&timezone=auto`
+        );
+
+        if (!response.ok) {
+          throw new Error(`Väderdata kunde inte hämtas: ${response.status}`);
+        }
+
+        const data = await response.json();
+        
+        if (data && data.current) {
+          const weatherCode = data.current.weather_code;
+          
+          setWeatherData({
+            temperature: data.current.temperature_2m,
+            windSpeed: data.current.wind_speed_10m,
+            weatherCode,
+            weatherDescription: weatherCodeToDescription(weatherCode),
+            isLoading: false,
+            error: null
+          });
+        } else {
+          throw new Error('Ogiltig väderdata från API');
+        }
+      } catch (error) {
+        setWeatherData(prevState => ({
+          ...prevState,
+          isLoading: false,
+          error: error instanceof Error ? error.message : 'Ett okänt fel uppstod'
+        }));
+      }
+    };
+
+    setWeatherData(prevState => ({ ...prevState, isLoading: true }));
+    fetchWeatherData();
+  }, [latitude, longitude]);
+
+  return weatherData;
+};


### PR DESCRIPTION
## Summary
- Adds a 'Vägbeskrivning' (Directions) button to the lake details panel
- When clicked, opens Google Maps in a new tab with directions to the selected lake
- Uses the lake's coordinates for precise navigation
- Reinstated weather service files that were missing from the branch

## Technical Implementation
- Added a button in the SidePanel header next to the lake name
- Used GeoJSON coordinates to generate a Google Maps directions URL
- Added proper tests to verify functionality
- Ensured compatibility with both mobile and desktop Google Maps

## Test plan
- Select a lake and verify the directions button appears
- Click the button and confirm it opens Google Maps in a new tab
- Verify the coordinates in the Google Maps URL match the lake's coordinates
- Test on both desktop and mobile devices to ensure it opens appropriately

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)