### PR TITLE
Add Google Maps directions feature (#38)

### DIFF
--- a/src/components/DirectionsForm.tsx
+++ b/src/components/DirectionsForm.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { 
+  TextField, 
+  Button, 
+  Box, 
+  Typography, 
+  Paper,
+  InputAdornment 
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+import DirectionsIcon from '@mui/icons-material/Directions';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+
+interface DirectionsFormProps {
+  destinationCoords: [number, number] | null; // [longitude, latitude]
+  destinationName: string | null;
+}
+
+const StyledPaper = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(2),
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: theme.palette.background.paper,
+}));
+
+const DirectionsForm: React.FC<DirectionsFormProps> = ({ 
+  destinationCoords, 
+  destinationName 
+}) => {
+  const [origin, setOrigin] = useState<string>('');
+
+  // Function to handle opening Google Maps directions
+  const handleGetDirections = () => {
+    if (!destinationCoords) return;
+    
+    // Google Maps expects coordinates in "latitude,longitude" format
+    const destination = `${destinationCoords[1]},${destinationCoords[0]}`;
+    const encodedOrigin = encodeURIComponent(origin);
+    const encodedDestination = encodeURIComponent(destination);
+    
+    // Open Google Maps in a new tab with directions
+    window.open(
+      `https://www.google.com/maps/dir/?api=1&origin=${encodedOrigin}&destination=${encodedDestination}`,
+      '_blank'
+    );
+  };
+
+  // Don't render if no destination is selected
+  if (!destinationCoords || !destinationName) return null;
+
+  return (
+    <StyledPaper elevation={2}>
+      <Typography variant="subtitle1" gutterBottom>
+        Hitta vägen till {destinationName}
+      </Typography>
+      <Box display="flex" flexDirection="column" gap={1}>
+        <TextField
+          label="Din plats"
+          value={origin}
+          onChange={(e) => setOrigin(e.target.value)}
+          fullWidth
+          placeholder="Ange din startpunkt"
+          size="small"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <LocationOnIcon color="primary" fontSize="small" />
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Button
+          variant="contained"
+          color="primary"
+          disabled={!origin.trim()}
+          onClick={handleGetDirections}
+          startIcon={<DirectionsIcon />}
+          size="medium"
+        >
+          Visa vägbeskrivning
+        </Button>
+      </Box>
+    </StyledPaper>
+  );
+};
+
+export default DirectionsForm;

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -10,6 +10,7 @@ import {
   Box
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import DirectionsForm from './DirectionsForm';
 
 interface SidePanelProps {
   selectedLake: GeoJsonFeature | null;
@@ -100,6 +101,13 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
           />
         </ListItem>
       </List>
+      
+      <Divider sx={{ my: 2 }} />
+      
+      <DirectionsForm 
+        destinationCoords={selectedLake.geometry.coordinates}
+        destinationName={selectedLake.properties.name}
+      />
     </StyledSidePanel>
   );
 };

--- a/src/components/__tests__/DirectionsForm.test.tsx
+++ b/src/components/__tests__/DirectionsForm.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DirectionsForm from '../DirectionsForm';
+
+// Mock window.open
+const mockOpen = jest.fn();
+Object.defineProperty(window, 'open', {
+  writable: true,
+  value: mockOpen
+});
+
+describe('DirectionsForm', () => {
+  const mockProps = {
+    destinationCoords: [18.123456, 59.123456] as [number, number], // [longitude, latitude]
+    destinationName: 'Test Lake'
+  };
+
+  beforeEach(() => {
+    mockOpen.mockClear();
+  });
+
+  it('renders correctly with destination information', () => {
+    render(<DirectionsForm {...mockProps} />);
+    
+    expect(screen.getByText(`Hitta vägen till ${mockProps.destinationName}`)).toBeInTheDocument();
+    expect(screen.getByLabelText('Din plats')).toBeInTheDocument();
+    expect(screen.getByText('Visa vägbeskrivning')).toBeInTheDocument();
+  });
+
+  it('does not render when destination is null', () => {
+    const { container } = render(
+      <DirectionsForm destinationCoords={null} destinationName={null} />
+    );
+    
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('updates input value when typing', () => {
+    render(<DirectionsForm {...mockProps} />);
+    
+    const input = screen.getByLabelText('Din plats');
+    fireEvent.change(input, { target: { value: 'Stockholm' } });
+    
+    expect(input).toHaveValue('Stockholm');
+  });
+
+  it('enables the button when input has a value', () => {
+    render(<DirectionsForm {...mockProps} />);
+    
+    const button = screen.getByText('Visa vägbeskrivning');
+    expect(button).toBeDisabled();
+    
+    const input = screen.getByLabelText('Din plats');
+    fireEvent.change(input, { target: { value: 'Stockholm' } });
+    
+    expect(button).not.toBeDisabled();
+  });
+
+  it('opens Google Maps with correct parameters when clicking the button', () => {
+    render(<DirectionsForm {...mockProps} />);
+    
+    const input = screen.getByLabelText('Din plats');
+    fireEvent.change(input, { target: { value: 'Stockholm' } });
+    
+    const button = screen.getByText('Visa vägbeskrivning');
+    fireEvent.click(button);
+    
+    // Note: Google Maps expects coordinates as "latitude,longitude"
+    const expectedDestination = `${mockProps.destinationCoords[1]},${mockProps.destinationCoords[0]}`;
+    const expectedUrl = `https://www.google.com/maps/dir/?api=1&origin=${encodeURIComponent('Stockholm')}&destination=${encodeURIComponent(expectedDestination)}`;
+    
+    expect(mockOpen).toHaveBeenCalledWith(expectedUrl, '_blank');
+  });
+});


### PR DESCRIPTION
## Summary
- Created a new directions interface at the bottom of the SidePanel
- Users can enter their location and get directions to the selected lake via Google Maps
- The interface is visually appealing and matches the application's style
- When clicked, it opens Google Maps in a new tab with directions from the user's location to the lake

## Test plan
- Verified the component renders correctly in the SidePanel
- Added comprehensive tests for the DirectionsForm component
- Checked that the form successfully opens Google Maps with correct parameters
- Tested UI behavior (disabled button until location is entered)

Fixes #38