### PR TITLE
Add minimize/maximize button to the right filter panel

### DIFF
--- a/src/components/SpeciesFilter.tsx
+++ b/src/components/SpeciesFilter.tsx
@@ -9,16 +9,26 @@ import {
   Checkbox,
   Stack,
   Divider,
-  Box
+  Box,
+  IconButton,
+  Tooltip
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 
 interface SpeciesFilterProps {
   features: GeoJsonFeature[];
   onFilterChange: (selectedSpecies: Set<string>) => void;
 }
 
-const StyledFilterPanel = styled(Paper)(({ theme }) => ({
+interface StyledFilterPanelProps {
+  minimized: boolean;
+}
+
+const StyledFilterPanel = styled(Paper, {
+  shouldForwardProp: (prop) => prop !== 'minimized'
+})<StyledFilterPanelProps>(({ theme, minimized }) => ({
   position: 'absolute',
   top: theme.spacing(2),
   right: theme.spacing(2),
@@ -26,14 +36,18 @@ const StyledFilterPanel = styled(Paper)(({ theme }) => ({
   zIndex: 1000,
   maxHeight: '80vh',
   overflow: 'auto',
-  width: 250,
+  width: minimized ? 'auto' : 250,
   boxShadow: theme.shadows[3],
-  borderRadius: theme.shape.borderRadius
+  borderRadius: theme.shape.borderRadius,
+  transition: theme.transitions.create(['width', 'transform'], {
+    duration: theme.transitions.duration.standard,
+  })
 }));
 
 const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange }) => {
   const [uniqueSpecies, setUniqueSpecies] = useState<string[]>([]);
   const [selectedSpecies, setSelectedSpecies] = useState<Set<string>>(new Set());
+  const [minimized, setMinimized] = useState<boolean>(false);
 
   useEffect(() => {
     const speciesSet = new Set<string>();
@@ -82,53 +96,71 @@ const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange 
   };
 
   return (
-    <StyledFilterPanel className="filter-panel">
-      <Typography variant="subtitle1" color="primary" fontWeight="medium" gutterBottom className="filter-header">
-        Filtrera efter arter
-      </Typography>
-      
-      <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
-        <Button 
-          size="small" 
-          variant="outlined" 
-          onClick={handleSelectAll}
-          color="primary"
-        >
-          Välj alla
-        </Button>
-        <Button 
-          size="small" 
-          variant="outlined" 
-          onClick={handleClearAll}
-          color="secondary"
-        >
-          Rensa alla
-        </Button>
-      </Stack>
-      
-      <Divider sx={{ mb: 2 }} />
-      
-      <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
-        <FormGroup>
-          {uniqueSpecies.map(species => (
-            <FormControlLabel
-              key={species}
-              control={
-                <Checkbox
-                  checked={selectedSpecies.has(species)}
-                  onChange={(e) => handleCheckboxChange(species, e.target.checked)}
-                  size="small"
-                  color="primary"
-                />
-              }
-              label={
-                <Typography variant="body2">{species}</Typography>
-              }
-              sx={{ mb: 0.5 }}
-            />
-          ))}
-        </FormGroup>
+    <StyledFilterPanel className="filter-panel" minimized={minimized}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        {!minimized && (
+          <Typography variant="subtitle1" color="primary" fontWeight="medium" className="filter-header">
+            Filtrera efter arter
+          </Typography>
+        )}
+        <Tooltip title={minimized ? "Expandera" : "Minimera"}>
+          <IconButton 
+            color="primary" 
+            onClick={() => setMinimized(!minimized)}
+            size="small"
+            sx={{ ml: minimized ? 0 : 1 }}
+          >
+            {minimized ? <KeyboardArrowLeftIcon /> : <KeyboardArrowRightIcon />}
+          </IconButton>
+        </Tooltip>
       </Box>
+      
+      {!minimized && (
+        <>
+          <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+            <Button 
+              size="small" 
+              variant="outlined" 
+              onClick={handleSelectAll}
+              color="primary"
+            >
+              Välj alla
+            </Button>
+            <Button 
+              size="small" 
+              variant="outlined" 
+              onClick={handleClearAll}
+              color="secondary"
+            >
+              Rensa alla
+            </Button>
+          </Stack>
+          
+          <Divider sx={{ mb: 2 }} />
+          
+          <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
+            <FormGroup>
+              {uniqueSpecies.map(species => (
+                <FormControlLabel
+                  key={species}
+                  control={
+                    <Checkbox
+                      checked={selectedSpecies.has(species)}
+                      onChange={(e) => handleCheckboxChange(species, e.target.checked)}
+                      size="small"
+                      color="primary"
+                    />
+                  }
+                  label={
+                    <Typography variant="body2">{species}</Typography>
+                  }
+                  sx={{ mb: 0.5 }}
+                />
+              ))}
+            </FormGroup>
+          </Box>
+        </>
+      )}
     </StyledFilterPanel>
   );
 };

--- a/src/components/__tests__/SpeciesFilter.test.tsx
+++ b/src/components/__tests__/SpeciesFilter.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SpeciesFilter from '../SpeciesFilter';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
@@ -174,5 +174,47 @@ describe('SpeciesFilter', () => {
     
     const checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes).toHaveLength(0);
+  });
+
+  it('renders with minimize button', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    // Check that the filter header and minimize button are present
+    expect(screen.getByText('Filtrera efter arter')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /minimera/i })).toBeInTheDocument();
+  });
+
+  it('minimizes and maximizes the panel when button is clicked', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    // Initially the panel should be expanded
+    expect(screen.getByText('Filtrera efter arter')).toBeInTheDocument();
+    expect(screen.getByText('Välj alla')).toBeInTheDocument();
+    expect(screen.getByText('Rensa alla')).toBeInTheDocument();
+    
+    // Click the minimize button
+    const minimizeButton = screen.getByRole('button', { name: /minimera/i });
+    fireEvent.click(minimizeButton);
+    
+    // After minimizing, content should be hidden
+    expect(screen.queryByText('Filtrera efter arter')).not.toBeInTheDocument();
+    expect(screen.queryByText('Välj alla')).not.toBeInTheDocument();
+    expect(screen.queryByText('Rensa alla')).not.toBeInTheDocument();
+    
+    // But expand button should be visible
+    expect(screen.getByRole('button', { name: /expandera/i })).toBeInTheDocument();
+    
+    // Click the expand button
+    const expandButton = screen.getByRole('button', { name: /expandera/i });
+    fireEvent.click(expandButton);
+    
+    // After expanding, content should be visible again
+    expect(screen.getByText('Filtrera efter arter')).toBeInTheDocument();
+    expect(screen.getByText('Välj alla')).toBeInTheDocument();
+    expect(screen.getByText('Rensa alla')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Added a minimize/maximize button to the species filter panel on the right side
- Implemented a minimized state that collapses the panel to just show the expand button
- Added appropriate test cases for the new functionality

## Test plan
- Verify that the minimize button appears in the top right of the filter panel
- Check that clicking the minimize button collapses the panel to just show the expand button
- Confirm that clicking the expand button restores the panel to its original state
- Run tests to ensure all functionality works correctly