### PR TITLE
Add minimize button to the right filter panel

### DIFF
--- a/src/components/SpeciesFilter.tsx
+++ b/src/components/SpeciesFilter.tsx
@@ -9,9 +9,13 @@ import {
   Checkbox,
   Stack,
   Divider,
-  Box
+  Box,
+  IconButton,
+  Tooltip
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 
 interface SpeciesFilterProps {
   features: GeoJsonFeature[];
@@ -28,12 +32,35 @@ const StyledFilterPanel = styled(Paper)(({ theme }) => ({
   overflow: 'auto',
   width: 250,
   boxShadow: theme.shadows[3],
-  borderRadius: theme.shape.borderRadius
+  borderRadius: theme.shape.borderRadius,
+  transition: 'width 0.3s ease-in-out'
+}));
+
+const MinimizeButton = styled(IconButton)(({ theme }) => ({
+  position: 'absolute',
+  top: theme.spacing(1),
+  right: theme.spacing(1),
+  zIndex: 1100,
+  padding: theme.spacing(0.5)
+}));
+
+const CollapsedPanel = styled(Paper)(({ theme }) => ({
+  position: 'absolute',
+  top: theme.spacing(2),
+  right: theme.spacing(2),
+  padding: theme.spacing(1),
+  zIndex: 1000,
+  borderRadius: theme.shape.borderRadius,
+  boxShadow: theme.shadows[3],
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center'
 }));
 
 const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange }) => {
   const [uniqueSpecies, setUniqueSpecies] = useState<string[]>([]);
   const [selectedSpecies, setSelectedSpecies] = useState<Set<string>>(new Set());
+  const [isExpanded, setIsExpanded] = useState<boolean>(true);
 
   useEffect(() => {
     const speciesSet = new Set<string>();
@@ -81,55 +108,94 @@ const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange 
     onFilterChange(new Set());
   };
 
+  const toggleExpanded = () => {
+    setIsExpanded(!isExpanded);
+  };
+
   return (
-    <StyledFilterPanel className="filter-panel">
-      <Typography variant="subtitle1" color="primary" fontWeight="medium" gutterBottom className="filter-header">
-        Filtrera efter arter
-      </Typography>
-      
-      <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
-        <Button 
-          size="small" 
-          variant="outlined" 
-          onClick={handleSelectAll}
-          color="primary"
-        >
-          Välj alla
-        </Button>
-        <Button 
-          size="small" 
-          variant="outlined" 
-          onClick={handleClearAll}
-          color="secondary"
-        >
-          Rensa alla
-        </Button>
-      </Stack>
-      
-      <Divider sx={{ mb: 2 }} />
-      
-      <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
-        <FormGroup>
-          {uniqueSpecies.map(species => (
-            <FormControlLabel
-              key={species}
-              control={
-                <Checkbox
-                  checked={selectedSpecies.has(species)}
-                  onChange={(e) => handleCheckboxChange(species, e.target.checked)}
-                  size="small"
-                  color="primary"
+    <>
+      {isExpanded ? (
+        <StyledFilterPanel className="filter-panel">
+          <Typography variant="subtitle1" color="primary" fontWeight="medium" gutterBottom className="filter-header">
+            Filtrera efter arter
+          </Typography>
+          
+          <Tooltip title="Minimera panel">
+            <MinimizeButton 
+              onClick={toggleExpanded} 
+              size="small" 
+              color="primary"
+              aria-label="minimize panel"
+            >
+              <KeyboardArrowRightIcon fontSize="small" />
+            </MinimizeButton>
+          </Tooltip>
+          
+          <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+            <Button 
+              size="small" 
+              variant="outlined" 
+              onClick={handleSelectAll}
+              color="primary"
+            >
+              Välj alla
+            </Button>
+            <Button 
+              size="small" 
+              variant="outlined" 
+              onClick={handleClearAll}
+              color="secondary"
+            >
+              Rensa alla
+            </Button>
+          </Stack>
+          
+          <Divider sx={{ mb: 2 }} />
+          
+          <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
+            <FormGroup>
+              {uniqueSpecies.map(species => (
+                <FormControlLabel
+                  key={species}
+                  control={
+                    <Checkbox
+                      checked={selectedSpecies.has(species)}
+                      onChange={(e) => handleCheckboxChange(species, e.target.checked)}
+                      size="small"
+                      color="primary"
+                    />
+                  }
+                  label={
+                    <Typography variant="body2">{species}</Typography>
+                  }
+                  sx={{ mb: 0.5 }}
                 />
-              }
-              label={
-                <Typography variant="body2">{species}</Typography>
-              }
-              sx={{ mb: 0.5 }}
-            />
-          ))}
-        </FormGroup>
-      </Box>
-    </StyledFilterPanel>
+              ))}
+            </FormGroup>
+          </Box>
+        </StyledFilterPanel>
+      ) : (
+        <CollapsedPanel>
+          <Tooltip title="Expandera panel">
+            <IconButton 
+              onClick={toggleExpanded} 
+              size="small" 
+              color="primary"
+              aria-label="expand panel"
+            >
+              <KeyboardArrowLeftIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          {selectedSpecies.size > 0 && (
+            <Box ml={1}>
+              <Typography variant="caption" color="primary">
+                {selectedSpecies.size} filter aktiva
+              </Typography>
+            </Box>
+          )}
+        </CollapsedPanel>
+      )}
+    </>
   );
 };
 

--- a/src/components/__tests__/SpeciesFilter.test.tsx
+++ b/src/components/__tests__/SpeciesFilter.test.tsx
@@ -175,4 +175,46 @@ describe('SpeciesFilter', () => {
     const checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes).toHaveLength(0);
   });
+
+  it('toggles between expanded and collapsed states when minimize/maximize button is clicked', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    // Initially expanded
+    expect(screen.getByText('Filtrera efter arter')).toBeInTheDocument();
+    
+    // Click minimize button
+    const minimizeButton = screen.getByLabelText('minimize panel');
+    fireEvent.click(minimizeButton);
+    
+    // Should be collapsed now
+    expect(screen.queryByText('Filtrera efter arter')).not.toBeInTheDocument();
+    
+    // Click expand button
+    const expandButton = screen.getByLabelText('expand panel');
+    fireEvent.click(expandButton);
+    
+    // Should be expanded again
+    expect(screen.getByText('Filtrera efter arter')).toBeInTheDocument();
+  });
+
+  it('shows the number of active filters when collapsed', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre', 'Gös'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    // Select some filters
+    const gaddaCheckbox = screen.getByLabelText('Gädda') as HTMLInputElement;
+    const abborCheckbox = screen.getByLabelText('Abborre') as HTMLInputElement;
+    fireEvent.click(gaddaCheckbox);
+    fireEvent.click(abborCheckbox);
+    
+    // Click minimize button
+    const minimizeButton = screen.getByLabelText('minimize panel');
+    fireEvent.click(minimizeButton);
+    
+    // Should show the number of active filters
+    expect(screen.getByText('2 filter aktiva')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Added a minimize/maximize toggle button for the species filter panel
- When minimized, the panel shows a small icon to expand and displays the count of active filters
- Added smooth transitions with animations for better UX
- Included comprehensive tests for the new functionality

## Test plan
1. Open the application
2. Verify the filter panel has a minimize button in the top right
3. Click the button to collapse the panel
4. Verify the panel collapses and shows an expand button
5. Apply some filters and minimize again
6. Verify the minimized panel shows the count of active filters
7. Click to expand and verify the panel returns to normal state

Closes #32