### PR TITLE
Add driving directions using Google Maps

### DIFF
--- a/src/components/DirectionsPanel.tsx
+++ b/src/components/DirectionsPanel.tsx
@@ -1,0 +1,170 @@
+import React, { useState } from 'react';
+import {
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  Box,
+  Divider,
+  Radio,
+  RadioGroup,
+  FormControlLabel,
+  FormControl,
+  FormLabel,
+  CircularProgress,
+  Alert
+} from '@mui/material';
+import DirectionsIcon from '@mui/icons-material/Directions';
+import MyLocationIcon from '@mui/icons-material/MyLocation';
+import { styled } from '@mui/material/styles';
+import { GeoJsonFeature } from '../types/GeoJsonTypes';
+
+interface DirectionsPanelProps {
+  selectedLake: GeoJsonFeature;
+}
+
+const StyledDirectionsPanel = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  marginTop: theme.spacing(2),
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: theme.palette.background.default
+}));
+
+const DirectionsPanel: React.FC<DirectionsPanelProps> = ({ selectedLake }) => {
+  const [locationType, setLocationType] = useState<'current' | 'manual'>('current');
+  const [manualAddress, setManualAddress] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  
+  // Google Maps destination coordinates from the lake
+  const destinationCoords = selectedLake.geometry.coordinates;
+  // Leaflet uses [lat, lng] whereas GeoJSON uses [lng, lat]
+  const lakeLatitude = destinationCoords[1];
+  const lakeLongitude = destinationCoords[0];
+  
+  const handleLocationTypeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setLocationType(event.target.value as 'current' | 'manual');
+    setError(null);
+  };
+  
+  const handleAddressChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setManualAddress(event.target.value);
+    setError(null);
+  };
+  
+  const getCurrentLocation = (): Promise<GeolocationPosition> => {
+    return new Promise((resolve, reject) => {
+      if (!navigator.geolocation) {
+        reject(new Error('Geolocation is not supported by your browser'));
+        return;
+      }
+      
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        enableHighAccuracy: true,
+        timeout: 5000,
+        maximumAge: 0
+      });
+    });
+  };
+  
+  const handleGetDirections = async () => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      let directionsUrl = '';
+      
+      if (locationType === 'current') {
+        try {
+          const position = await getCurrentLocation();
+          const { latitude, longitude } = position.coords;
+          directionsUrl = `https://www.google.com/maps/dir/${latitude},${longitude}/${lakeLatitude},${lakeLongitude}`;
+        } catch (err) {
+          throw new Error('Kunde inte hämta din position. Kontrollera att du har gett behörighet för att dela din plats.');
+        }
+      } else {
+        if (!manualAddress.trim()) {
+          throw new Error('Vänligen ange en adress för att få vägbeskrivningar');
+        }
+        // Use the address for directions
+        directionsUrl = `https://www.google.com/maps/dir/${encodeURIComponent(manualAddress)}/${lakeLatitude},${lakeLongitude}`;
+      }
+      
+      // Open Google Maps in a new tab
+      window.open(directionsUrl, '_blank');
+    } catch (err: any) {
+      setError(err.message || 'Ett fel uppstod när vägbeskrivningar skulle hämtas');
+    } finally {
+      setLoading(false);
+    }
+  };
+  
+  return (
+    <StyledDirectionsPanel elevation={1}>
+      <Typography variant="subtitle1" color="primary" gutterBottom fontWeight="medium">
+        Vägbeskrivning
+      </Typography>
+      <Divider sx={{ mb: 2 }} />
+      
+      <FormControl component="fieldset" sx={{ mb: 2 }}>
+        <FormLabel component="legend">Startplats</FormLabel>
+        <RadioGroup
+          value={locationType}
+          onChange={handleLocationTypeChange}
+          row
+        >
+          <FormControlLabel 
+            value="current" 
+            control={<Radio size="small" />} 
+            label={
+              <Box display="flex" alignItems="center">
+                <MyLocationIcon fontSize="small" sx={{ mr: 0.5 }} />
+                <Typography variant="body2">Min position</Typography>
+              </Box>
+            }
+          />
+          <FormControlLabel 
+            value="manual" 
+            control={<Radio size="small" />} 
+            label={
+              <Typography variant="body2">Ange adress</Typography>
+            }
+          />
+        </RadioGroup>
+      </FormControl>
+      
+      {locationType === 'manual' && (
+        <TextField
+          fullWidth
+          size="small"
+          label="Adress"
+          variant="outlined"
+          value={manualAddress}
+          onChange={handleAddressChange}
+          placeholder="Ange startadress"
+          margin="normal"
+          sx={{ mb: 2 }}
+        />
+      )}
+      
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+      
+      <Button
+        fullWidth
+        variant="contained"
+        color="primary"
+        startIcon={loading ? <CircularProgress size={20} color="inherit" /> : <DirectionsIcon />}
+        onClick={handleGetDirections}
+        disabled={loading || (locationType === 'manual' && !manualAddress.trim())}
+      >
+        {loading ? 'Hämtar...' : 'Visa vägbeskrivning'}
+      </Button>
+    </StyledDirectionsPanel>
+  );
+};
+
+export default DirectionsPanel;

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -10,6 +10,7 @@ import {
   Box
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import DirectionsPanel from './DirectionsPanel';
 
 interface SidePanelProps {
   selectedLake: GeoJsonFeature | null;
@@ -100,6 +101,9 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
           />
         </ListItem>
       </List>
+      
+      {/* Directions Panel */}
+      <DirectionsPanel selectedLake={selectedLake} />
     </StyledSidePanel>
   );
 };

--- a/src/components/__tests__/DirectionsPanel.test.tsx
+++ b/src/components/__tests__/DirectionsPanel.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DirectionsPanel from '../DirectionsPanel';
+import { GeoJsonFeature } from '../../types/GeoJsonTypes';
+
+// Mock window.open
+const mockOpen = jest.fn();
+window.open = mockOpen;
+
+// Mock navigator.geolocation
+const mockGeolocation = {
+  getCurrentPosition: jest.fn(),
+  watchPosition: jest.fn(),
+  clearWatch: jest.fn()
+};
+
+Object.defineProperty(global.navigator, 'geolocation', {
+  value: mockGeolocation,
+  writable: true
+});
+
+describe('DirectionsPanel', () => {
+  const mockLake: GeoJsonFeature = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [18.0579, 59.3293] // longitude, latitude
+    },
+    properties: {
+      name: 'Test Lake',
+      county: 'Test County',
+      maxDepth: 25,
+      area: 500
+    }
+  };
+
+  beforeEach(() => {
+    mockOpen.mockClear();
+    mockGeolocation.getCurrentPosition.mockClear();
+  });
+
+  it('renders correctly with default selection (current location)', () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Check if the panel title is rendered
+    expect(screen.getByText('Vägbeskrivning')).toBeInTheDocument();
+    
+    // Check that the "current location" option is selected by default
+    const currentLocationRadio = screen.getByLabelText(/Min position/i);
+    expect(currentLocationRadio).toBeChecked();
+    
+    // Check that the manual address option exists
+    expect(screen.getByLabelText(/Ange adress/i)).toBeInTheDocument();
+    
+    // Check that the address input is not visible initially
+    expect(screen.queryByPlaceholderText('Ange startadress')).not.toBeInTheDocument();
+    
+    // Check that the directions button is present
+    expect(screen.getByText('Visa vägbeskrivning')).toBeInTheDocument();
+  });
+
+  it('shows the address input when manual option is selected', () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Select the manual address option
+    const manualRadio = screen.getByLabelText(/Ange adress/i);
+    fireEvent.click(manualRadio);
+    
+    // Check that the address input is now visible
+    const addressInput = screen.getByPlaceholderText('Ange startadress');
+    expect(addressInput).toBeInTheDocument();
+    
+    // The button should be disabled because no address is entered
+    const directionButton = screen.getByText('Visa vägbeskrivning');
+    expect(directionButton).toBeDisabled();
+    
+    // Enter an address
+    fireEvent.change(addressInput, { target: { value: 'Stockholm, Sweden' } });
+    
+    // Now the button should be enabled
+    expect(directionButton).not.toBeDisabled();
+  });
+
+  it('opens Google Maps with correct URL for manual address', async () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Select the manual address option
+    const manualRadio = screen.getByLabelText(/Ange adress/i);
+    fireEvent.click(manualRadio);
+    
+    // Enter an address
+    const addressInput = screen.getByPlaceholderText('Ange startadress');
+    fireEvent.change(addressInput, { target: { value: 'Stockholm, Sweden' } });
+    
+    // Click the directions button
+    const directionButton = screen.getByText('Visa vägbeskrivning');
+    fireEvent.click(directionButton);
+    
+    // Check that window.open was called with the correct URL
+    await waitFor(() => {
+      expect(mockOpen).toHaveBeenCalledWith(
+        `https://www.google.com/maps/dir/${encodeURIComponent('Stockholm, Sweden')}/59.3293,18.0579`,
+        '_blank'
+      );
+    });
+  });
+
+  it('opens Google Maps with geolocation coordinates when current location is selected', async () => {
+    // Mock successful geolocation
+    mockGeolocation.getCurrentPosition.mockImplementationOnce((success) => {
+      success({
+        coords: {
+          latitude: 60.1282,
+          longitude: 18.6435
+        }
+      });
+    });
+    
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Current location should be selected by default
+    // Click the directions button
+    const directionButton = screen.getByText('Visa vägbeskrivning');
+    fireEvent.click(directionButton);
+    
+    // Check that geolocation was called
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalled();
+    
+    // Check that window.open was called with the correct URL
+    await waitFor(() => {
+      expect(mockOpen).toHaveBeenCalledWith(
+        'https://www.google.com/maps/dir/60.1282,18.6435/59.3293,18.0579',
+        '_blank'
+      );
+    });
+  });
+
+  it('shows an error when geolocation fails', async () => {
+    // Mock geolocation failure
+    mockGeolocation.getCurrentPosition.mockImplementationOnce((success, error) => {
+      error(new Error('Geolocation error'));
+    });
+    
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Click the directions button
+    const directionButton = screen.getByText('Visa vägbeskrivning');
+    fireEvent.click(directionButton);
+    
+    // Check that geolocation was called
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalled();
+    
+    // Check that an error is displayed
+    await waitFor(() => {
+      expect(screen.getByText(/Kunde inte hämta din position/i)).toBeInTheDocument();
+    });
+    
+    // Check that window.open was not called
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/SidePanel.test.tsx
+++ b/src/components/__tests__/SidePanel.test.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import SidePanel from '../SidePanel';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
+
+// Mock the DirectionsPanel to simplify testing
+jest.mock('../DirectionsPanel', () => {
+  return function MockDirectionsPanel({ selectedLake }: { selectedLake: GeoJsonFeature }) {
+    return <div data-testid="directions-panel">Directions Mock for {selectedLake.properties.name}</div>;
+  };
+});
 
 describe('SidePanel', () => {
   const mockLake: GeoJsonFeature = {
@@ -40,5 +48,13 @@ describe('SidePanel', () => {
     expect(screen.getByText('Pike (60%)')).toBeInTheDocument();
     expect(screen.getByText('Perch (40%)')).toBeInTheDocument();
     expect(screen.getByText('2023')).toBeInTheDocument();
+  });
+
+  it('includes the DirectionsPanel when a lake is selected', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+    
+    // Check that the directions panel is included
+    expect(screen.getByTestId('directions-panel')).toBeInTheDocument();
+    expect(screen.getByText(`Directions Mock for ${mockLake.properties.name}`)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Added a directions panel at the bottom of the side panel that allows users to get driving directions to selected lakes
- Implemented two options for starting location:
  1. Use current location (automatically detected with geolocation API)
  2. Enter a manual address or location
- Added visual feedback with loading indicators and error messages
- Opens Google Maps in a new tab with the route pre-configured
- Designed with Material UI components for a consistent look and feel

## Test plan
1. Open the application and select a lake
2. Verify the directions panel appears at the bottom of the side panel
3. Test the current location option:
   - Click the directions button
   - Allow location access when prompted
   - Verify Google Maps opens with directions from your location to the lake
4. Test the manual address option:
   - Select the manual address option
   - Enter a start location in the text field
   - Click the directions button
   - Verify Google Maps opens with directions from the entered location to the lake

Closes #38