### PR TITLE
Add minimize button to the right filter panel

### DIFF
--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GeoJsonFeature } from '../types/GeoJsonTypes';
 import { 
   Paper, 
@@ -7,33 +7,78 @@ import {
   ListItem, 
   ListItemText, 
   Divider,
-  Box
+  Box,
+  IconButton
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 
 interface SidePanelProps {
   selectedLake: GeoJsonFeature | null;
 }
 
-const StyledSidePanel = styled(Paper)(({ theme }) => ({
-  width: 300,
-  padding: theme.spacing(3),
+interface StyledSidePanelProps {
+  isMinimized: boolean;
+}
+
+const StyledSidePanel = styled(Paper, {
+  shouldForwardProp: (prop) => prop !== 'isMinimized'
+})<StyledSidePanelProps>(({ theme, isMinimized }) => ({
+  width: isMinimized ? 42 : 300,
+  padding: isMinimized ? theme.spacing(1, 0) : theme.spacing(3),
   height: '100vh',
   overflow: 'auto',
   boxShadow: theme.shadows[3],
   zIndex: 1000,
-  position: 'relative'
+  position: 'relative',
+  transition: theme.transitions.create('width', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.enteringScreen,
+  }),
 }));
 
 const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
+  const [isMinimized, setIsMinimized] = useState(false);
+  
+  const toggleMinimize = () => {
+    setIsMinimized(!isMinimized);
+  };
+  
+  // Render the minimize/maximize button
+  const MinimizeButton = () => (
+    <IconButton
+      onClick={toggleMinimize}
+      sx={{
+        position: 'absolute',
+        right: isMinimized ? '4px' : '12px',
+        top: '12px',
+        zIndex: 1100,
+        backgroundColor: 'rgba(255, 255, 255, 0.7)',
+        '&:hover': {
+          backgroundColor: 'rgba(255, 255, 255, 0.9)',
+        },
+        border: '1px solid #eee',
+      }}
+      size="small"
+      aria-label={isMinimized ? 'Expand panel' : 'Minimize panel'}
+      title={isMinimized ? 'Visa panel' : 'Minimera panel'}
+    >
+      {isMinimized ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+    </IconButton>
+  );
+
   if (!selectedLake) {
     return (
-      <StyledSidePanel>
-        <Box display="flex" justifyContent="center" alignItems="center" height="100%">
-          <Typography variant="body1" color="text.secondary">
-            Välj en sjö på kartan för att se mer information
-          </Typography>
-        </Box>
+      <StyledSidePanel isMinimized={isMinimized}>
+        <MinimizeButton />
+        {!isMinimized && (
+          <Box display="flex" justifyContent="center" alignItems="center" height="100%">
+            <Typography variant="body1" color="text.secondary">
+              Välj en sjö på kartan för att se mer information
+            </Typography>
+          </Box>
+        )}
       </StyledSidePanel>
     );
   }
@@ -45,61 +90,67 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
   };
 
   return (
-    <StyledSidePanel>
-      <Typography variant="h5" component="h2" gutterBottom color="primary">
-        {selectedLake.properties.name}
-      </Typography>
-      <Divider sx={{ mb: 2 }} />
-      <List disablePadding>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Maxdjup" 
-            secondary={selectedLake.properties.maxDepth !== null ? `${selectedLake.properties.maxDepth} m` : 'Okänt'} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Area" 
-            secondary={selectedLake.properties.area !== null && selectedLake.properties.area !== undefined
-              ? `${selectedLake.properties.area.toLocaleString()} ha`
-              : 'Okänd'} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Län" 
-            secondary={selectedLake.properties.county} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Fångade arter" 
-            secondary={renderCaughtSpecies(selectedLake.properties.catchedSpecies || selectedLake.properties.fångadeArter)} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Vanligaste art" 
-            secondary={selectedLake.properties.vanlArt
-              ? `${selectedLake.properties.vanlArt} (${selectedLake.properties.vanlArtWProc}%)`
-              : 'Okänd'} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Näst vanligaste art" 
-            secondary={selectedLake.properties.nästVanlArt
-              ? `${selectedLake.properties.nästVanlArt} (${selectedLake.properties.nästVanlArtWProc}%)`
-              : 'Okänd'} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Senaste fiskeår" 
-            secondary={selectedLake.properties.senasteFiskeår || 'Okänt'} 
-          />
-        </ListItem>
-      </List>
+    <StyledSidePanel isMinimized={isMinimized}>
+      <MinimizeButton />
+      
+      {!isMinimized && (
+        <>
+          <Typography variant="h5" component="h2" gutterBottom color="primary">
+            {selectedLake.properties.name}
+          </Typography>
+          <Divider sx={{ mb: 2 }} />
+          <List disablePadding>
+            <ListItem sx={{ py: 1 }}>
+              <ListItemText 
+                primary="Maxdjup" 
+                secondary={selectedLake.properties.maxDepth !== null ? `${selectedLake.properties.maxDepth} m` : 'Okänt'} 
+              />
+            </ListItem>
+            <ListItem sx={{ py: 1 }}>
+              <ListItemText 
+                primary="Area" 
+                secondary={selectedLake.properties.area !== null && selectedLake.properties.area !== undefined
+                  ? `${selectedLake.properties.area.toLocaleString()} ha`
+                  : 'Okänd'} 
+              />
+            </ListItem>
+            <ListItem sx={{ py: 1 }}>
+              <ListItemText 
+                primary="Län" 
+                secondary={selectedLake.properties.county} 
+              />
+            </ListItem>
+            <ListItem sx={{ py: 1 }}>
+              <ListItemText 
+                primary="Fångade arter" 
+                secondary={renderCaughtSpecies(selectedLake.properties.catchedSpecies || selectedLake.properties.fångadeArter)} 
+              />
+            </ListItem>
+            <ListItem sx={{ py: 1 }}>
+              <ListItemText 
+                primary="Vanligaste art" 
+                secondary={selectedLake.properties.vanlArt
+                  ? `${selectedLake.properties.vanlArt} (${selectedLake.properties.vanlArtWProc}%)`
+                  : 'Okänd'} 
+              />
+            </ListItem>
+            <ListItem sx={{ py: 1 }}>
+              <ListItemText 
+                primary="Näst vanligaste art" 
+                secondary={selectedLake.properties.nästVanlArt
+                  ? `${selectedLake.properties.nästVanlArt} (${selectedLake.properties.nästVanlArtWProc}%)`
+                  : 'Okänd'} 
+              />
+            </ListItem>
+            <ListItem sx={{ py: 1 }}>
+              <ListItemText 
+                primary="Senaste fiskeår" 
+                secondary={selectedLake.properties.senasteFiskeår || 'Okänt'} 
+              />
+            </ListItem>
+          </List>
+        </>
+      )}
     </StyledSidePanel>
   );
 };

--- a/src/components/__tests__/SidePanel.test.tsx
+++ b/src/components/__tests__/SidePanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import SidePanel from '../SidePanel';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
 
@@ -40,5 +40,28 @@ describe('SidePanel', () => {
     expect(screen.getByText('Pike (60%)')).toBeInTheDocument();
     expect(screen.getByText('Perch (40%)')).toBeInTheDocument();
     expect(screen.getByText('2023')).toBeInTheDocument();
+  });
+
+  it('has a minimize button', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+    const minimizeButton = screen.getByRole('button', { name: /Minimize panel/i });
+    expect(minimizeButton).toBeInTheDocument();
+  });
+
+  it('hides content when minimize button is clicked', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+    
+    // Content should be visible initially
+    expect(screen.getByText('Test Lake')).toBeInTheDocument();
+    
+    // Click minimize button
+    const minimizeButton = screen.getByRole('button', { name: /Minimize panel/i });
+    fireEvent.click(minimizeButton);
+    
+    // Content should be hidden
+    expect(screen.queryByText('Test Lake')).not.toBeInTheDocument();
+    
+    // Button should now be for expanding
+    expect(screen.getByRole('button', { name: /Expand panel/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Added a minimize/maximize button to the right side of the side panel
- When minimized, the panel collapses to a narrow strip and hides content
- Added smooth animation for transitions between states
- Button uses chevron icons to indicate direction
- Added tests for the new functionality

## Test plan
- Verify that the side panel shows a minimize button
- Click the button to collapse the panel
- Verify that the panel content is hidden
- Click the button again to expand the panel
- Verify that panel content is displayed again

Fixes #32

🤖 Generated with [Claude Code](https://claude.ai/code)