### PR TITLE
Driving directions using Google Maps

### DIFF
--- a/src/components/DirectionsPanel.tsx
+++ b/src/components/DirectionsPanel.tsx
@@ -1,0 +1,186 @@
+import React, { useState } from 'react';
+import { 
+  Box, 
+  Button, 
+  Typography, 
+  TextField, 
+  CircularProgress, 
+  Paper, 
+  Divider,
+  IconButton, 
+  Switch,
+  FormControlLabel,
+  Collapse,
+  Alert
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+import MyLocationIcon from '@mui/icons-material/MyLocation';
+import DirectionsIcon from '@mui/icons-material/Directions';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { GeoJsonFeature } from '../types/GeoJsonTypes';
+
+interface DirectionsPanelProps {
+  selectedLake: GeoJsonFeature;
+}
+
+const StyledDirectionsPanel = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  marginTop: theme.spacing(3),
+  boxShadow: theme.shadows[1],
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: theme.palette.background.paper,
+}));
+
+const DirectionsPanel: React.FC<DirectionsPanelProps> = ({ selectedLake }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [startLocation, setStartLocation] = useState('');
+  const [useCurrentLocation, setUseCurrentLocation] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  
+  // Extract latitude and longitude from the lake feature
+  const lakeLatitude = selectedLake.geometry.coordinates[1];
+  const lakeLongitude = selectedLake.geometry.coordinates[0];
+  
+  const handleToggleExpand = () => {
+    setExpanded(!expanded);
+  };
+  
+  const handleToggleUseCurrentLocation = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setUseCurrentLocation(event.target.checked);
+    if (event.target.checked) {
+      setStartLocation('');
+    }
+  };
+  
+  const handleGetDirections = () => {
+    if (useCurrentLocation) {
+      getCurrentLocation();
+    } else if (startLocation) {
+      openGoogleMapsWithAddress();
+    } else {
+      setError('Please enter a starting location or use your current location');
+    }
+  };
+  
+  const getCurrentLocation = () => {
+    setLoading(true);
+    setError(null);
+    
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const { latitude, longitude } = position.coords;
+          openGoogleMapsWithCoordinates(latitude, longitude);
+          setLoading(false);
+        },
+        (err) => {
+          console.error('Error getting current location:', err);
+          setError('Failed to get your location. Please check browser permissions or enter an address manually.');
+          setLoading(false);
+        }
+      );
+    } else {
+      setError('Geolocation is not supported by your browser. Please enter an address manually.');
+      setLoading(false);
+    }
+  };
+  
+  const openGoogleMapsWithCoordinates = (startLat: number, startLng: number) => {
+    const url = `https://www.google.com/maps/dir/?api=1&origin=${startLat},${startLng}&destination=${lakeLatitude},${lakeLongitude}&travelmode=driving`;
+    window.open(url, '_blank');
+  };
+  
+  const openGoogleMapsWithAddress = () => {
+    const encodedAddress = encodeURIComponent(startLocation);
+    const url = `https://www.google.com/maps/dir/?api=1&origin=${encodedAddress}&destination=${lakeLatitude},${lakeLongitude}&travelmode=driving`;
+    window.open(url, '_blank');
+  };
+  
+  return (
+    <StyledDirectionsPanel>
+      <Box 
+        display="flex" 
+        justifyContent="space-between" 
+        alignItems="center" 
+        onClick={handleToggleExpand}
+        sx={{ cursor: 'pointer' }}
+      >
+        <Typography variant="subtitle1" color="primary" fontWeight="medium">
+          Driving Directions
+        </Typography>
+        <IconButton size="small">
+          {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </Box>
+      
+      <Collapse in={expanded}>
+        <Divider sx={{ my: 1.5 }} />
+        
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+            {error}
+          </Alert>
+        )}
+        
+        <FormControlLabel
+          control={
+            <Switch 
+              checked={useCurrentLocation} 
+              onChange={handleToggleUseCurrentLocation}
+              color="primary"
+            />
+          }
+          label="Use my current location"
+        />
+        
+        {!useCurrentLocation && (
+          <TextField
+            fullWidth
+            size="small"
+            variant="outlined"
+            label="Enter your starting location"
+            value={startLocation}
+            onChange={(e) => setStartLocation(e.target.value)}
+            margin="normal"
+            placeholder="Enter address, city or postal code"
+            disabled={useCurrentLocation}
+          />
+        )}
+        
+        <Box display="flex" justifyContent="space-between" mt={2}>
+          {useCurrentLocation && (
+            <Button
+              startIcon={<MyLocationIcon />}
+              variant="outlined"
+              size="small"
+              color="primary"
+              onClick={getCurrentLocation}
+              disabled={loading}
+            >
+              Get My Location
+            </Button>
+          )}
+          
+          <Button
+            startIcon={loading ? <CircularProgress size={20} /> : <DirectionsIcon />}
+            variant="contained"
+            color="primary"
+            onClick={handleGetDirections}
+            disabled={loading || (!useCurrentLocation && !startLocation)}
+            fullWidth={!useCurrentLocation}
+          >
+            Get Directions
+          </Button>
+        </Box>
+        
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1.5 }}>
+          Directions will open in Google Maps.
+        </Typography>
+      </Collapse>
+    </StyledDirectionsPanel>
+  );
+};
+
+export default DirectionsPanel;

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -10,6 +10,7 @@ import {
   Box
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import DirectionsPanel from './DirectionsPanel';
 
 interface SidePanelProps {
   selectedLake: GeoJsonFeature | null;
@@ -100,6 +101,9 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
           />
         </ListItem>
       </List>
+      
+      {/* Add the DirectionsPanel component */}
+      <DirectionsPanel selectedLake={selectedLake} />
     </StyledSidePanel>
   );
 };

--- a/src/components/__tests__/DirectionsPanel.test.tsx
+++ b/src/components/__tests__/DirectionsPanel.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DirectionsPanel from '../DirectionsPanel';
+import { GeoJsonFeature } from '../../types/GeoJsonTypes';
+
+// Mock window.open
+const mockOpen = jest.fn();
+window.open = mockOpen;
+
+// Mock navigator.geolocation
+const mockGeolocation = {
+  getCurrentPosition: jest.fn(),
+};
+(global as any).navigator.geolocation = mockGeolocation;
+
+describe('DirectionsPanel', () => {
+  const mockLake: GeoJsonFeature = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [18.0686, 59.3293] // [longitude, latitude]
+    },
+    properties: {
+      name: 'Test Lake',
+      county: 'Test County',
+      location: 'Test Location',
+      maxDepth: 10,
+      area: 1000,
+      elevation: 50
+    }
+  };
+
+  beforeEach(() => {
+    mockOpen.mockClear();
+    mockGeolocation.getCurrentPosition.mockClear();
+  });
+
+  it('renders collapsed by default', () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    expect(screen.getByText('Driving Directions')).toBeInTheDocument();
+    // Check that the collapse element has the hidden class
+    const collapseEl = screen.getByText('Directions will open in Google Maps.').closest('.MuiCollapse-hidden');
+    expect(collapseEl).toBeTruthy();
+  });
+
+  it('expands when clicked', () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Click the header to expand
+    fireEvent.click(screen.getByText('Driving Directions'));
+    
+    // Verify the collapse is no longer hidden
+    expect(screen.queryByText('Directions will open in Google Maps.').closest('.MuiCollapse-hidden')).toBeFalsy();
+    expect(screen.getByText('Use my current location')).toBeInTheDocument();
+    expect(screen.getByText('Get Directions')).toBeInTheDocument();
+  });
+
+  it('allows entering a starting location', () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Expand the panel
+    fireEvent.click(screen.getByText('Driving Directions'));
+    
+    const input = screen.getByLabelText('Enter your starting location');
+    fireEvent.change(input, { target: { value: 'Stockholm, Sweden' } });
+    
+    expect(input).toHaveValue('Stockholm, Sweden');
+  });
+
+  it('opens Google Maps with address when Get Directions is clicked', () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Expand the panel
+    fireEvent.click(screen.getByText('Driving Directions'));
+    
+    // Enter starting location
+    const input = screen.getByLabelText('Enter your starting location');
+    fireEvent.change(input, { target: { value: 'Stockholm, Sweden' } });
+    
+    // Click Get Directions
+    fireEvent.click(screen.getByText('Get Directions'));
+    
+    // Check if window.open was called with the correct URL
+    expect(mockOpen).toHaveBeenCalledWith(
+      'https://www.google.com/maps/dir/?api=1&origin=Stockholm%2C%20Sweden&destination=59.3293,18.0686&travelmode=driving',
+      '_blank'
+    );
+  });
+
+  it('toggles to use current location when switch is clicked', () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Expand the panel
+    fireEvent.click(screen.getByText('Driving Directions'));
+    
+    // Toggle to use current location
+    const toggle = screen.getByLabelText('Use my current location');
+    fireEvent.click(toggle);
+    
+    // Check that the input is no longer visible
+    expect(screen.queryByLabelText('Enter your starting location')).not.toBeInTheDocument();
+    expect(screen.getByText('Get My Location')).toBeInTheDocument();
+  });
+
+  it('uses geolocation when Get My Location is clicked', () => {
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Expand the panel
+    fireEvent.click(screen.getByText('Driving Directions'));
+    
+    // Toggle to use current location
+    const toggle = screen.getByLabelText('Use my current location');
+    fireEvent.click(toggle);
+    
+    // Click Get My Location
+    fireEvent.click(screen.getByText('Get My Location'));
+    
+    // Check if getCurrentPosition was called
+    expect(mockGeolocation.getCurrentPosition).toHaveBeenCalled();
+  });
+
+  it('handles successful geolocation', async () => {
+    // Mock successful geolocation
+    mockGeolocation.getCurrentPosition.mockImplementationOnce((success) => {
+      success({ coords: { latitude: 60.1282, longitude: 18.6435 } });
+    });
+    
+    render(<DirectionsPanel selectedLake={mockLake} />);
+    
+    // Expand the panel
+    fireEvent.click(screen.getByText('Driving Directions'));
+    
+    // Toggle to use current location
+    const toggle = screen.getByLabelText('Use my current location');
+    fireEvent.click(toggle);
+    
+    // Click Get My Location
+    fireEvent.click(screen.getByText('Get My Location'));
+    
+    // Check if window.open was called with the correct URL
+    await waitFor(() => {
+      expect(mockOpen).toHaveBeenCalledWith(
+        'https://www.google.com/maps/dir/?api=1&origin=60.1282,18.6435&destination=59.3293,18.0686&travelmode=driving',
+        '_blank'
+      );
+    });
+  });
+});

--- a/src/components/__tests__/SidePanel.test.tsx
+++ b/src/components/__tests__/SidePanel.test.tsx
@@ -3,6 +3,13 @@ import { render, screen } from '@testing-library/react';
 import SidePanel from '../SidePanel';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
 
+// Mock the DirectionsPanel component to simplify testing
+jest.mock('../DirectionsPanel', () => {
+  return function MockDirectionsPanel({ selectedLake }: { selectedLake: GeoJsonFeature }) {
+    return <div data-testid="directions-panel">Directions Panel Mock</div>;
+  };
+});
+
 describe('SidePanel', () => {
   const mockLake: GeoJsonFeature = {
     type: 'Feature',
@@ -40,5 +47,15 @@ describe('SidePanel', () => {
     expect(screen.getByText('Pike (60%)')).toBeInTheDocument();
     expect(screen.getByText('Perch (40%)')).toBeInTheDocument();
     expect(screen.getByText('2023')).toBeInTheDocument();
+  });
+
+  it('includes the DirectionsPanel when a lake is selected', () => {
+    render(<SidePanel selectedLake={mockLake} />);
+    expect(screen.getByTestId('directions-panel')).toBeInTheDocument();
+  });
+
+  it('does not include the DirectionsPanel when no lake is selected', () => {
+    render(<SidePanel selectedLake={null} />);
+    expect(screen.queryByTestId('directions-panel')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Added a collapsible directions panel at the bottom of the lake information sidebar
- Implemented ability to get directions from either current location or a manually entered address
- Integrated with Google Maps for directions via URL
- Created visually appealing UI with expandable panel, intuitive controls, and user-friendly error messages
- Added comprehensive tests for the new functionality

## Test plan
1. Select a lake on the map to display its information
2. Scroll to the bottom of the side panel and verify the 'Driving Directions' section
3. Click to expand the section
4. Try both options:
   - Toggle 'Use my current location' and click 'Get Directions'
   - Enter an address manually and click 'Get Directions'
5. Verify Google Maps opens in a new tab with the correct starting and destination locations

Fixes #38

🤖 Generated with [Claude Code](https://claude.ai/code)