### PR TITLE
Fix #68: Add minimize button to right filter panel

### DIFF
--- a/src/components/SpeciesFilter.tsx
+++ b/src/components/SpeciesFilter.tsx
@@ -9,9 +9,13 @@ import {
   Checkbox,
   Stack,
   Divider,
-  Box
+  Box,
+  IconButton,
+  Collapse
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import MinimizeIcon from '@mui/icons-material/Minimize';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 interface SpeciesFilterProps {
   features: GeoJsonFeature[];
@@ -22,18 +26,34 @@ const StyledFilterPanel = styled(Paper)(({ theme }) => ({
   position: 'absolute',
   top: theme.spacing(2),
   right: theme.spacing(2),
-  padding: theme.spacing(2),
+  padding: 0,
   zIndex: 1000,
   maxHeight: '80vh',
-  overflow: 'auto',
   width: 250,
   boxShadow: theme.shadows[3],
-  borderRadius: theme.shape.borderRadius
+  borderRadius: theme.shape.borderRadius,
+  transition: theme.transitions.create(['width'], {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen,
+  }),
+}));
+
+const FilterHeader = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: theme.spacing(2),
+  paddingBottom: theme.spacing(1),
+}));
+
+const FilterContent = styled(Box)(({ theme }) => ({
+  padding: theme.spacing(0, 2, 2),
 }));
 
 const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange }) => {
   const [uniqueSpecies, setUniqueSpecies] = useState<string[]>([]);
   const [selectedSpecies, setSelectedSpecies] = useState<Set<string>>(new Set());
+  const [isMinimized, setIsMinimized] = useState<boolean>(false);
 
   useEffect(() => {
     const speciesSet = new Set<string>();
@@ -81,54 +101,72 @@ const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange 
     onFilterChange(new Set());
   };
 
+  const toggleMinimize = () => {
+    setIsMinimized(!isMinimized);
+  };
+
   return (
     <StyledFilterPanel className="filter-panel">
-      <Typography variant="subtitle1" color="primary" fontWeight="medium" gutterBottom className="filter-header">
-        Filtrera efter arter
-      </Typography>
-      
-      <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
-        <Button 
-          size="small" 
-          variant="outlined" 
-          onClick={handleSelectAll}
+      <FilterHeader>
+        <Typography variant="subtitle1" color="primary" fontWeight="medium" className="filter-header">
+          Filtrera efter arter
+        </Typography>
+        <IconButton
+          onClick={toggleMinimize}
+          size="small"
+          aria-label={isMinimized ? "Visa filter" : "Dölj filter"}
           color="primary"
         >
-          Välj alla
-        </Button>
-        <Button 
-          size="small" 
-          variant="outlined" 
-          onClick={handleClearAll}
-          color="secondary"
-        >
-          Rensa alla
-        </Button>
-      </Stack>
+          {isMinimized ? <ExpandMoreIcon /> : <MinimizeIcon />}
+        </IconButton>
+      </FilterHeader>
       
-      <Divider sx={{ mb: 2 }} />
-      
-      <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
-        <FormGroup>
-          {uniqueSpecies.map(species => (
-            <FormControlLabel
-              key={species}
-              control={
-                <Checkbox
-                  checked={selectedSpecies.has(species)}
-                  onChange={(e) => handleCheckboxChange(species, e.target.checked)}
-                  size="small"
-                  color="primary"
+      <Collapse in={!isMinimized} timeout="auto" unmountOnExit>
+        <FilterContent>
+          <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+            <Button 
+              size="small" 
+              variant="outlined" 
+              onClick={handleSelectAll}
+              color="primary"
+            >
+              Välj alla
+            </Button>
+            <Button 
+              size="small" 
+              variant="outlined" 
+              onClick={handleClearAll}
+              color="secondary"
+            >
+              Rensa alla
+            </Button>
+          </Stack>
+          
+          <Divider sx={{ mb: 2 }} />
+          
+          <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
+            <FormGroup>
+              {uniqueSpecies.map(species => (
+                <FormControlLabel
+                  key={species}
+                  control={
+                    <Checkbox
+                      checked={selectedSpecies.has(species)}
+                      onChange={(e) => handleCheckboxChange(species, e.target.checked)}
+                      size="small"
+                      color="primary"
+                    />
+                  }
+                  label={
+                    <Typography variant="body2">{species}</Typography>
+                  }
+                  sx={{ mb: 0.5 }}
                 />
-              }
-              label={
-                <Typography variant="body2">{species}</Typography>
-              }
-              sx={{ mb: 0.5 }}
-            />
-          ))}
-        </FormGroup>
-      </Box>
+              ))}
+            </FormGroup>
+          </Box>
+        </FilterContent>
+      </Collapse>
     </StyledFilterPanel>
   );
 };

--- a/src/components/__tests__/SpeciesFilter.test.tsx
+++ b/src/components/__tests__/SpeciesFilter.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SpeciesFilter from '../SpeciesFilter';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
@@ -174,5 +174,58 @@ describe('SpeciesFilter', () => {
     
     const checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes).toHaveLength(0);
+  });
+
+  it('shows minimize/maximize button', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    const minimizeButton = screen.getByLabelText('Dölj filter');
+    expect(minimizeButton).toBeInTheDocument();
+  });
+
+  it('toggles panel visibility when minimize button is clicked', async () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    // Initially the content should be visible
+    expect(screen.getByText('Välj alla')).toBeInTheDocument();
+    expect(screen.getByText('Rensa alla')).toBeInTheDocument();
+    
+    // Click minimize button
+    const minimizeButton = screen.getByLabelText('Dölj filter');
+    fireEvent.click(minimizeButton);
+    
+    // Wait for the collapse animation and content to be hidden
+    await waitFor(() => {
+      expect(screen.queryByText('Välj alla')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('Rensa alla')).not.toBeInTheDocument();
+    
+    // Button label should change
+    const maximizeButton = screen.getByLabelText('Visa filter');
+    expect(maximizeButton).toBeInTheDocument();
+  });
+
+  it('shows content again when maximize button is clicked', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    // Minimize first
+    const minimizeButton = screen.getByLabelText('Dölj filter');
+    fireEvent.click(minimizeButton);
+    
+    // Then maximize
+    const maximizeButton = screen.getByLabelText('Visa filter');
+    fireEvent.click(maximizeButton);
+    
+    // Content should be visible again
+    expect(screen.getByText('Välj alla')).toBeInTheDocument();
+    expect(screen.getByText('Rensa alla')).toBeInTheDocument();
+    expect(screen.getByText('Gädda')).toBeInTheDocument();
+    expect(screen.getByText('Abborre')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
• Adds minimize/maximize functionality to the species filter panel
• Smooth collapse animation with intuitive icons and accessibility

## Test plan
- [x] Added toggle button with proper icons (minimize/expand)
- [x] Implemented smooth collapse animation using Material UI
- [x] Enhanced test coverage for minimize/maximize behavior
- [x] Build completes successfully
- [x] All existing filter functionality preserved

🤖 Generated with [Claude Code](https://claude.ai/code)