### PR TITLE
Implement lake search functionality with autocomplete

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import Map from './components/Map';
 import SpeciesFilter from './components/SpeciesFilter';
 import SidePanel from './components/SidePanel';
+import LakeSearch from './components/LakeSearch';
 import { GeoJsonCollection, GeoJsonFeature } from './types/GeoJsonTypes';
 import { mergeGeoJsonCollections, removeBOM, convertLakeDataToGeoJson } from './utils/DataLoader';
 
@@ -37,6 +38,7 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [filteredSpecies, setFilteredSpecies] = useState<Set<string>>(new Set());
   const [selectedLake, setSelectedLake] = useState<GeoJsonFeature | null>(null);
+  const [focusLake, setFocusLake] = useState<GeoJsonFeature | null>(null);
 
   useEffect(() => {
     fetchAllLakeData();
@@ -125,6 +127,11 @@ function App() {
     setFilteredSpecies(selectedSpecies);
   };
 
+  const handleLakeSearchSelect = (lake: GeoJsonFeature) => {
+    setSelectedLake(lake);
+    setFocusLake(lake);
+  };
+
   if (isLoading) {
     return (
       <ThemeProvider theme={theme}>
@@ -172,7 +179,9 @@ function App() {
           data={data}
           filteredSpecies={filteredSpecies}
           onLakeSelect={setSelectedLake}
+          focusLake={focusLake}
         />
+        <LakeSearch features={data.features} onLakeSelect={handleLakeSearchSelect} />
         <SpeciesFilter features={data.features} onFilterChange={handleFilterChange} />
       </div>
     </ThemeProvider>

--- a/src/components/LakeSearch.tsx
+++ b/src/components/LakeSearch.tsx
@@ -1,0 +1,144 @@
+import React, { useState, useEffect } from 'react';
+import { 
+  Paper,
+  TextField,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  Typography,
+  Box
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { GeoJsonFeature } from '../types/GeoJsonTypes';
+
+interface LakeSearchProps {
+  features: GeoJsonFeature[];
+  onLakeSelect: (lake: GeoJsonFeature) => void;
+}
+
+const StyledSearchPanel = styled(Paper)(({ theme }) => ({
+  position: 'absolute',
+  top: theme.spacing(2),
+  right: theme.spacing(2),
+  zIndex: 1001,
+  width: 250,
+  boxShadow: theme.shadows[3],
+  borderRadius: theme.shape.borderRadius
+}));
+
+const StyledTextField = styled(TextField)(({ theme }) => ({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: theme.shape.borderRadius,
+  }
+}));
+
+const LakeSearch: React.FC<LakeSearchProps> = ({ features, onLakeSelect }) => {
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [suggestions, setSuggestions] = useState<GeoJsonFeature[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (searchTerm.trim() === '') {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      return;
+    }
+
+    const filteredLakes = features
+      .filter(feature => 
+        feature.properties.name && 
+        feature.properties.name.toLowerCase().includes(searchTerm.toLowerCase())
+      )
+      .slice(0, 5); // Limit to 5 suggestions
+
+    setSuggestions(filteredLakes);
+    setShowSuggestions(filteredLakes.length > 0);
+  }, [searchTerm, features]);
+
+  const handleLakeSelect = (lake: GeoJsonFeature) => {
+    setSearchTerm(lake.properties.name || '');
+    setShowSuggestions(false);
+    onLakeSelect(lake);
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handleInputFocus = () => {
+    if (suggestions.length > 0) {
+      setShowSuggestions(true);
+    }
+  };
+
+  const handleInputBlur = () => {
+    // Delay hiding suggestions to allow clicking on them
+    setTimeout(() => setShowSuggestions(false), 200);
+  };
+
+  return (
+    <StyledSearchPanel>
+      <Box sx={{ p: 2 }}>
+        <Typography variant="subtitle1" color="primary" fontWeight="medium" gutterBottom>
+          Sök sjö
+        </Typography>
+        
+        <StyledTextField
+          fullWidth
+          size="small"
+          placeholder="Skriv sjönamn..."
+          value={searchTerm}
+          onChange={handleInputChange}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          variant="outlined"
+        />
+        
+        {showSuggestions && (
+          <Paper 
+            elevation={2} 
+            sx={{ 
+              mt: 1, 
+              maxHeight: 200, 
+              overflow: 'auto',
+              borderRadius: 1
+            }}
+          >
+            <List dense disablePadding>
+              {suggestions.map((lake, index) => (
+                <ListItem key={index} disablePadding>
+                  <ListItemButton
+                    onClick={() => handleLakeSelect(lake)}
+                    sx={{ 
+                      py: 1,
+                      '&:hover': {
+                        backgroundColor: 'primary.light',
+                        opacity: 0.1
+                      }
+                    }}
+                  >
+                    <ListItemText
+                      primary={
+                        <Typography variant="body2" fontWeight="medium">
+                          {lake.properties.name}
+                        </Typography>
+                      }
+                      secondary={
+                        <Typography variant="caption" color="text.secondary">
+                          {lake.properties.county}
+                        </Typography>
+                      }
+                    />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+          </Paper>
+        )}
+      </Box>
+    </StyledSearchPanel>
+  );
+};
+
+export default LakeSearch;

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,14 +1,30 @@
-import React from 'react';
-import { MapContainer, TileLayer, CircleMarker, Tooltip } from 'react-leaflet';
+import React, { useEffect, useRef } from 'react';
+import { MapContainer, TileLayer, CircleMarker, Tooltip, useMap } from 'react-leaflet';
 import { GeoJsonCollection, GeoJsonFeature } from '../types/GeoJsonTypes';
 
 interface MapProps {
   data: GeoJsonCollection;
   filteredSpecies: Set<string>;
   onLakeSelect: (lake: GeoJsonFeature) => void;
+  focusLake?: GeoJsonFeature | null;
 }
 
-const Map: React.FC<MapProps> = ({ data, filteredSpecies, onLakeSelect }) => {
+// Component to handle map focusing
+const MapFocusHandler: React.FC<{ focusLake: GeoJsonFeature | null }> = ({ focusLake }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    if (focusLake) {
+      const { coordinates } = focusLake.geometry;
+      const position: [number, number] = [coordinates[1], coordinates[0]];
+      map.setView(position, 12); // Zoom level 12 for lake detail
+    }
+  }, [focusLake, map]);
+
+  return null;
+};
+
+const Map: React.FC<MapProps> = ({ data, filteredSpecies, onLakeSelect, focusLake }) => {
   const swedenCenter: [number, number] = [62.0, 15.0];
   
   // Filter features based on selected species
@@ -59,12 +75,13 @@ const Map: React.FC<MapProps> = ({ data, filteredSpecies, onLakeSelect }) => {
         attribution="&copy; OpenStreetMap bidragsgivare"
         maxZoom={19}
       />
+      <MapFocusHandler focusLake={focusLake} />
       {getFilteredFeatures().map((feature, index) => {
         const { coordinates } = feature.geometry;
         // Leaflet uses [lat, lng] whereas GeoJSON uses [lng, lat]
         const position: [number, number] = [coordinates[1], coordinates[0]]; 
         
-        const fillColor = '#3388ff';
+        const fillColor = filteredSpecies.size > 0 ? '#ff4444' : '#3388ff';
         
         return (
           <CircleMarker 

--- a/src/components/SpeciesFilter.tsx
+++ b/src/components/SpeciesFilter.tsx
@@ -9,9 +9,12 @@ import {
   Checkbox,
   Stack,
   Divider,
-  Box
+  Box,
+  IconButton,
+  Collapse
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { ExpandMore, ExpandLess } from '@mui/icons-material';
 
 interface SpeciesFilterProps {
   features: GeoJsonFeature[];
@@ -20,11 +23,11 @@ interface SpeciesFilterProps {
 
 const StyledFilterPanel = styled(Paper)(({ theme }) => ({
   position: 'absolute',
-  top: theme.spacing(2),
+  top: theme.spacing(15), // Position below the search panel
   right: theme.spacing(2),
   padding: theme.spacing(2),
   zIndex: 1000,
-  maxHeight: '80vh',
+  maxHeight: '65vh',
   overflow: 'auto',
   width: 250,
   boxShadow: theme.shadows[3],
@@ -34,6 +37,7 @@ const StyledFilterPanel = styled(Paper)(({ theme }) => ({
 const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange }) => {
   const [uniqueSpecies, setUniqueSpecies] = useState<string[]>([]);
   const [selectedSpecies, setSelectedSpecies] = useState<Set<string>>(new Set());
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
 
   useEffect(() => {
     const speciesSet = new Set<string>();
@@ -83,52 +87,69 @@ const SpeciesFilter: React.FC<SpeciesFilterProps> = ({ features, onFilterChange 
 
   return (
     <StyledFilterPanel className="filter-panel">
-      <Typography variant="subtitle1" color="primary" fontWeight="medium" gutterBottom className="filter-header">
-        Filtrera efter arter
-      </Typography>
-      
-      <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
-        <Button 
-          size="small" 
-          variant="outlined" 
-          onClick={handleSelectAll}
-          color="primary"
+      <Stack direction="row" alignItems="center" sx={{ mb: isExpanded ? 2 : 0 }}>
+        <Typography variant="subtitle1" color="primary" fontWeight="medium" className="filter-header" sx={{ flexGrow: 1 }}>
+          Filtrera efter arter
+        </Typography>
+        <IconButton 
+          onClick={() => setIsExpanded(!isExpanded)}
+          size="small"
+          sx={{ 
+            color: 'primary.main',
+            '&:hover': {
+              backgroundColor: 'primary.light',
+              opacity: 0.1
+            }
+          }}
         >
-          Välj alla
-        </Button>
-        <Button 
-          size="small" 
-          variant="outlined" 
-          onClick={handleClearAll}
-          color="secondary"
-        >
-          Rensa alla
-        </Button>
+          {isExpanded ? <ExpandLess /> : <ExpandMore />}
+        </IconButton>
       </Stack>
       
-      <Divider sx={{ mb: 2 }} />
-      
-      <Box sx={{ maxHeight: '60vh', overflow: 'auto' }}>
-        <FormGroup>
-          {uniqueSpecies.map(species => (
-            <FormControlLabel
-              key={species}
-              control={
-                <Checkbox
-                  checked={selectedSpecies.has(species)}
-                  onChange={(e) => handleCheckboxChange(species, e.target.checked)}
-                  size="small"
-                  color="primary"
-                />
-              }
-              label={
-                <Typography variant="body2">{species}</Typography>
-              }
-              sx={{ mb: 0.5 }}
-            />
-          ))}
-        </FormGroup>
-      </Box>
+      <Collapse in={isExpanded} data-testid="filter-content">
+        <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+          <Button 
+            size="small" 
+            variant="outlined" 
+            onClick={handleSelectAll}
+            color="primary"
+          >
+            Välj alla
+          </Button>
+          <Button 
+            size="small" 
+            variant="outlined" 
+            onClick={handleClearAll}
+            color="secondary"
+          >
+            Rensa alla
+          </Button>
+        </Stack>
+        
+        <Divider sx={{ mb: 2 }} />
+        
+        <Box sx={{ maxHeight: '50vh', overflow: 'auto' }}>
+          <FormGroup>
+            {uniqueSpecies.map(species => (
+              <FormControlLabel
+                key={species}
+                control={
+                  <Checkbox
+                    checked={selectedSpecies.has(species)}
+                    onChange={(e) => handleCheckboxChange(species, e.target.checked)}
+                    size="small"
+                    color="primary"
+                  />
+                }
+                label={
+                  <Typography variant="body2">{species}</Typography>
+                }
+                sx={{ mb: 0.5 }}
+              />
+            ))}
+          </FormGroup>
+        </Box>
+      </Collapse>
     </StyledFilterPanel>
   );
 };

--- a/src/components/__tests__/LakeSearch.test.tsx
+++ b/src/components/__tests__/LakeSearch.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LakeSearch from '../LakeSearch';
+import { GeoJsonFeature } from '../../types/GeoJsonTypes';
+
+describe('LakeSearch', () => {
+  const mockOnLakeSelect = jest.fn();
+
+  const createMockLake = (name: string, county: string): GeoJsonFeature => ({
+    type: 'Feature' as const,
+    geometry: {
+      type: 'Point' as const,
+      coordinates: [18.0579, 59.3293] as [number, number]
+    },
+    properties: {
+      name,
+      county,
+      location: 'Test Location',
+      maxDepth: 10,
+      area: 100,
+      elevation: 50
+    }
+  });
+
+  beforeEach(() => {
+    mockOnLakeSelect.mockClear();
+  });
+
+  it('renders search input', () => {
+    const features = [createMockLake('Test Lake', 'Test County')];
+    
+    render(<LakeSearch features={features} onLakeSelect={mockOnLakeSelect} />);
+    
+    expect(screen.getByText('Sök sjö')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Skriv sjönamn...')).toBeInTheDocument();
+  });
+
+  it('shows suggestions when typing', () => {
+    const features = [
+      createMockLake('Vättern', 'Östergötland'),
+      createMockLake('Vänern', 'Västra Götaland'),
+      createMockLake('Mälaren', 'Stockholm')
+    ];
+    
+    render(<LakeSearch features={features} onLakeSelect={mockOnLakeSelect} />);
+    
+    const searchInput = screen.getByPlaceholderText('Skriv sjönamn...');
+    fireEvent.change(searchInput, { target: { value: 'Vä' } });
+    
+    expect(screen.getByText('Vättern')).toBeInTheDocument();
+    expect(screen.getByText('Vänern')).toBeInTheDocument();
+    expect(screen.queryByText('Mälaren')).not.toBeInTheDocument();
+  });
+
+  it('limits suggestions to 5 items', () => {
+    const features = Array.from({ length: 10 }, (_, i) => 
+      createMockLake(`Lake ${i}`, 'Test County')
+    );
+    
+    render(<LakeSearch features={features} onLakeSelect={mockOnLakeSelect} />);
+    
+    const searchInput = screen.getByPlaceholderText('Skriv sjönamn...');
+    fireEvent.change(searchInput, { target: { value: 'Lake' } });
+    
+    const suggestions = screen.getAllByText(/Lake \d/);
+    expect(suggestions).toHaveLength(5);
+  });
+
+  it('calls onLakeSelect when clicking a suggestion', () => {
+    const lake = createMockLake('Vättern', 'Östergötland');
+    const features = [lake];
+    
+    render(<LakeSearch features={features} onLakeSelect={mockOnLakeSelect} />);
+    
+    const searchInput = screen.getByPlaceholderText('Skriv sjönamn...');
+    fireEvent.change(searchInput, { target: { value: 'Vä' } });
+    
+    const suggestion = screen.getByText('Vättern');
+    fireEvent.click(suggestion);
+    
+    expect(mockOnLakeSelect).toHaveBeenCalledWith(lake);
+  });
+
+  it('updates search input value when selecting a lake', () => {
+    const features = [createMockLake('Vättern', 'Östergötland')];
+    
+    render(<LakeSearch features={features} onLakeSelect={mockOnLakeSelect} />);
+    
+    const searchInput = screen.getByPlaceholderText('Skriv sjönamn...') as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: 'Vä' } });
+    
+    const suggestion = screen.getByText('Vättern');
+    fireEvent.click(suggestion);
+    
+    expect(searchInput.value).toBe('Vättern');
+  });
+
+  it('hides suggestions when input is empty', () => {
+    const features = [createMockLake('Vättern', 'Östergötland')];
+    
+    render(<LakeSearch features={features} onLakeSelect={mockOnLakeSelect} />);
+    
+    const searchInput = screen.getByPlaceholderText('Skriv sjönamn...');
+    fireEvent.change(searchInput, { target: { value: 'Vä' } });
+    
+    expect(screen.getByText('Vättern')).toBeInTheDocument();
+    
+    fireEvent.change(searchInput, { target: { value: '' } });
+    
+    expect(screen.queryByText('Vättern')).not.toBeInTheDocument();
+  });
+
+  it('displays county information in suggestions', () => {
+    const features = [createMockLake('Vättern', 'Östergötland')];
+    
+    render(<LakeSearch features={features} onLakeSelect={mockOnLakeSelect} />);
+    
+    const searchInput = screen.getByPlaceholderText('Skriv sjönamn...');
+    fireEvent.change(searchInput, { target: { value: 'Vä' } });
+    
+    expect(screen.getByText('Östergötland')).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/Map.test.tsx
+++ b/src/components/__tests__/Map.test.tsx
@@ -10,12 +10,15 @@ jest.mock('react-leaflet', () => ({
     <div data-testid="map-container">{children}</div>
   ),
   TileLayer: () => <div data-testid="tile-layer" />,
-  CircleMarker: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="circle-marker">{children}</div>
+  CircleMarker: ({ children, pathOptions }: { children: React.ReactNode; pathOptions?: any }) => (
+    <div data-testid="circle-marker" data-fill-color={pathOptions?.fillColor}>{children}</div>
   ),
   Tooltip: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="tooltip">{children}</div>
   ),
+  useMap: () => ({
+    setView: jest.fn(),
+  }),
 }));
 
 describe('Map', () => {
@@ -52,7 +55,7 @@ describe('Map', () => {
     ];
     const data = createMockData(features);
 
-    render(<Map data={data} filteredSpecies={new Set()} />);
+    render(<Map data={data} filteredSpecies={new Set()} onLakeSelect={() => {}} />);
 
     const markers = screen.getAllByTestId('circle-marker');
     expect(markers).toHaveLength(2);
@@ -69,7 +72,7 @@ describe('Map', () => {
     ];
     const data = createMockData(features);
 
-    render(<Map data={data} filteredSpecies={new Set(['Gädda'])} />);
+    render(<Map data={data} filteredSpecies={new Set(['Gädda'])} onLakeSelect={() => {}} />);
 
     const markers = screen.getAllByTestId('circle-marker');
     expect(markers).toHaveLength(1);
@@ -85,7 +88,7 @@ describe('Map', () => {
     ];
     const data = createMockData(features);
 
-    render(<Map data={data} filteredSpecies={new Set(['Gädda'])} />);
+    render(<Map data={data} filteredSpecies={new Set(['Gädda'])} onLakeSelect={() => {}} />);
 
     const markers = screen.getAllByTestId('circle-marker');
     expect(markers).toHaveLength(1);
@@ -131,7 +134,7 @@ describe('Map', () => {
     ];
     const data = createMockData(features);
 
-    render(<Map data={data} filteredSpecies={new Set(['Gädda'])} />);
+    render(<Map data={data} filteredSpecies={new Set(['Gädda'])} onLakeSelect={() => {}} />);
 
     const markers = screen.getAllByTestId('circle-marker');
     expect(markers).toHaveLength(1);
@@ -161,7 +164,7 @@ describe('Map', () => {
     };
     const data = createMockData([feature]);
 
-    render(<Map data={data} filteredSpecies={new Set()} />);
+    render(<Map data={data} filteredSpecies={new Set()} onLakeSelect={() => {}} />);
 
     const tooltip = screen.getByTestId('tooltip');
     expect(tooltip).toHaveTextContent('Test Lake');
@@ -196,27 +199,45 @@ describe('Map', () => {
     };
     const data = createMockData([feature]);
 
-    render(<Map data={data} filteredSpecies={new Set()} />);
+    render(<Map data={data} filteredSpecies={new Set()} onLakeSelect={() => {}} />);
 
     const tooltip = screen.getByTestId('tooltip');
     expect(tooltip).toHaveTextContent('Vanligaste art: Gädda (45%)');
     expect(tooltip).toHaveTextContent('Näst vanligaste art: Abborre (30%)');
   });
 
-  it('renders all markers in blue color', () => {
+  it('renders all markers in blue color when no filter is applied', () => {
     const features = [
       createMockFeature('Lake 1', [18.0579, 59.3293], ['Gädda', 'Abborre']),
       createMockFeature('Lake 2', [17.0579, 58.3293], ['Gös', 'Abborre'])
     ];
     const data = createMockData(features);
 
-    render(<Map data={data} filteredSpecies={new Set()} />);
+    render(<Map data={data} filteredSpecies={new Set()} onLakeSelect={() => {}} />);
 
     const markers = screen.getAllByTestId('circle-marker');
     expect(markers).toHaveLength(2);
+    
+    markers.forEach(marker => {
+      expect(marker).toHaveAttribute('data-fill-color', '#3388ff');
+    });
+  });
 
-    // Since we're using mocked components, we can't directly test the color
-    // but this test ensures the code path is covered
+  it('renders filtered markers in red color when filter is applied', () => {
+    const features = [
+      createMockFeature('Lake 1', [18.0579, 59.3293], ['Gädda', 'Abborre']),
+      createMockFeature('Lake 2', [17.0579, 58.3293], ['Gös', 'Abborre'])
+    ];
+    const data = createMockData(features);
+
+    render(<Map data={data} filteredSpecies={new Set(['Gädda'])} onLakeSelect={() => {}} />);
+
+    const markers = screen.getAllByTestId('circle-marker');
+    expect(markers).toHaveLength(1);
+    
+    markers.forEach(marker => {
+      expect(marker).toHaveAttribute('data-fill-color', '#ff4444');
+    });
   });
 
   it('handles missing or null values in tooltip', () => {
@@ -237,7 +258,7 @@ describe('Map', () => {
     };
     const data = createMockData([feature]);
 
-    render(<Map data={data} filteredSpecies={new Set()} />);
+    render(<Map data={data} filteredSpecies={new Set()} onLakeSelect={() => {}} />);
 
     const tooltip = screen.getByTestId('tooltip');
     expect(tooltip).toHaveTextContent('Maxdjup: Okänt');

--- a/src/components/__tests__/SpeciesFilter.test.tsx
+++ b/src/components/__tests__/SpeciesFilter.test.tsx
@@ -28,7 +28,12 @@ describe('SpeciesFilter', () => {
     mockOnFilterChange.mockClear();
   });
 
-  it('renders species list from array data', () => {
+  const expandPanel = () => {
+    const expandButton = screen.getByRole('button');
+    fireEvent.click(expandButton);
+  };
+
+  it('renders filter panel header and starts minimized', () => {
     const features = [
       createMockFeature(['Gädda', 'Abborre']),
       createMockFeature(['Gös', 'Abborre'])
@@ -37,6 +42,25 @@ describe('SpeciesFilter', () => {
     render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
 
     expect(screen.getByText('Filtrera efter arter')).toBeInTheDocument();
+    
+    // Should start minimized, check the collapse container has correct attributes
+    const filterContent = screen.getByTestId('filter-content');
+    expect(filterContent).toHaveStyle('visibility: hidden');
+  });
+
+  it('expands to show species list when expand button is clicked', () => {
+    const features = [
+      createMockFeature(['Gädda', 'Abborre']),
+      createMockFeature(['Gös', 'Abborre'])
+    ];
+
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+
+    // Click the expand button
+    const expandButton = screen.getByRole('button');
+    fireEvent.click(expandButton);
+
+    // Now species should be visible
     expect(screen.getByText('Abborre')).toBeInTheDocument();
     expect(screen.getByText('Gädda')).toBeInTheDocument();
     expect(screen.getByText('Gös')).toBeInTheDocument();
@@ -49,6 +73,7 @@ describe('SpeciesFilter', () => {
     ];
 
     render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    expandPanel();
 
     expect(screen.getByText('Abborre')).toBeInTheDocument();
     expect(screen.getByText('Gädda')).toBeInTheDocument();
@@ -59,6 +84,7 @@ describe('SpeciesFilter', () => {
     const features = [createMockFeature(['Gädda', 'Abborre'])];
     
     render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    expandPanel();
     
     const gaddaCheckbox = screen.getByLabelText('Gädda') as HTMLInputElement;
     fireEvent.click(gaddaCheckbox);
@@ -75,6 +101,7 @@ describe('SpeciesFilter', () => {
     const features = [createMockFeature(['Gädda', 'Abborre', 'Gös'])];
     
     render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    expandPanel();
     
     const selectAllButton = screen.getByText('Välj alla');
     fireEvent.click(selectAllButton);
@@ -91,6 +118,7 @@ describe('SpeciesFilter', () => {
     const features = [createMockFeature(['Gädda', 'Abborre', 'Gös'])];
     
     render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    expandPanel();
     
     // First select all
     fireEvent.click(screen.getByText('Välj alla'));
@@ -145,6 +173,7 @@ describe('SpeciesFilter', () => {
     ];
 
     render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    expandPanel();
 
     expect(screen.getByText('Gädda')).toBeInTheDocument();
     expect(screen.getByText('Abborre')).toBeInTheDocument();
@@ -171,8 +200,31 @@ describe('SpeciesFilter', () => {
     ];
 
     render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    expandPanel();
     
     const checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes).toHaveLength(0);
+  });
+
+  it('toggles expand/collapse state when clicking the toggle button', () => {
+    const features = [createMockFeature(['Gädda', 'Abborre'])];
+    
+    render(<SpeciesFilter features={features} onFilterChange={mockOnFilterChange} />);
+    
+    const filterContent = screen.getByTestId('filter-content');
+    const toggleButton = screen.getByRole('button');
+    
+    // Initially collapsed
+    expect(filterContent).toHaveStyle('visibility: hidden');
+    
+    // Click to expand
+    fireEvent.click(toggleButton);
+    
+    // Now expanded - content should be visible
+    expect(screen.getByText('Gädda')).toBeInTheDocument();
+    expect(screen.getByText('Abborre')).toBeInTheDocument();
+    
+    // Test that expand button exists and can be clicked (basic functionality test)
+    expect(toggleButton).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Implements a lake search feature with real-time autocomplete suggestions
- Positioned above the filter panel as requested in the issue
- Map automatically re-focuses on the selected lake with appropriate zoom level

## Features
- **Real-time search**: Shows suggestions as user types lake names
- **Autocomplete dropdown**: Displays up to 5 matching lakes with name and county
- **Map integration**: Automatically focuses map on selected lake
- **Visual design**: Clean, Material-UI styled interface matching app theme
- **Filter panel enhancements**: Added minimize/maximize functionality
- **Color indicators**: Blue dots for normal view, red dots when filtering

## Test plan
- [x] Search input appears above filter panel
- [x] Typing shows relevant lake suggestions
- [x] Clicking suggestion focuses map on lake
- [x] Search suggestions are limited to 5 items
- [x] County information displayed in suggestions
- [x] Filter panel can be minimized/maximized
- [x] All existing functionality preserved
- [x] Comprehensive test coverage added

Fixes #69

🤖 Generated with [Claude Code](https://claude.ai/code)