### PR TITLE
Fix #71: Change map dots to red when filter is active

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -64,7 +64,7 @@ const Map: React.FC<MapProps> = ({ data, filteredSpecies, onLakeSelect }) => {
         // Leaflet uses [lat, lng] whereas GeoJSON uses [lng, lat]
         const position: [number, number] = [coordinates[1], coordinates[0]]; 
         
-        const fillColor = '#3388ff';
+        const fillColor = filteredSpecies.size > 0 ? '#ff0000' : '#3388ff';
         
         return (
           <CircleMarker 


### PR DESCRIPTION
## Summary
- Map markers now change color from blue to red when species filters are active
- Provides visual feedback to users that filtering is applied

## Test plan
- [x] Run unit tests (`npm test`)
- [x] Start the application and verify markers are blue by default
- [x] Apply a species filter and verify markers turn red
- [x] Remove filters and verify markers return to blue

🤖 Generated with [Claude Code](https://claude.ai/code)