### PR TITLE
Fix #67: Driving directions using Google Maps

### DIFF
--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GeoJsonFeature } from '../types/GeoJsonTypes';
 import { 
   Paper, 
@@ -7,9 +7,19 @@ import {
   ListItem, 
   ListItemText, 
   Divider,
-  Box
+  Box,
+  Button,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Stack,
+  CircularProgress,
+  Alert
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import MyLocationIcon from '@mui/icons-material/MyLocation';
+import LocationOnIcon from '@mui/icons-material/LocationOn';
+import DirectionsIcon from '@mui/icons-material/Directions';
 
 interface SidePanelProps {
   selectedLake: GeoJsonFeature | null;
@@ -22,10 +32,29 @@ const StyledSidePanel = styled(Paper)(({ theme }) => ({
   overflow: 'auto',
   boxShadow: theme.shadows[3],
   zIndex: 1000,
-  position: 'relative'
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column'
+}));
+
+const ContentSection = styled(Box)({
+  flex: '1 1 auto',
+  overflow: 'auto'
+});
+
+const DirectionsSection = styled(Box)(({ theme }) => ({
+  flex: '0 0 auto',
+  marginTop: theme.spacing(2),
+  paddingTop: theme.spacing(2),
+  borderTop: `1px solid ${theme.palette.divider}`
 }));
 
 const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
+  const [locationType, setLocationType] = useState<'current' | 'manual'>('current');
+  const [manualAddress, setManualAddress] = useState('');
+  const [isGettingLocation, setIsGettingLocation] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
+
   if (!selectedLake) {
     return (
       <StyledSidePanel>
@@ -44,62 +73,169 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
     return species;
   };
 
+  const handleGetDirections = async () => {
+    setLocationError(null);
+    
+    if (locationType === 'current') {
+      setIsGettingLocation(true);
+      
+      if (!navigator.geolocation) {
+        setLocationError('Din webbläsare stöder inte geolokalisering');
+        setIsGettingLocation(false);
+        return;
+      }
+
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          setIsGettingLocation(false);
+          const origin = `${position.coords.latitude},${position.coords.longitude}`;
+          openGoogleMapsDirections(origin);
+        },
+        (error) => {
+          setIsGettingLocation(false);
+          switch (error.code) {
+            case error.PERMISSION_DENIED:
+              setLocationError('Åtkomst till plats nekad');
+              break;
+            case error.POSITION_UNAVAILABLE:
+              setLocationError('Platsinformation är inte tillgänglig');
+              break;
+            case error.TIMEOUT:
+              setLocationError('Timeout vid hämtning av plats');
+              break;
+            default:
+              setLocationError('Ett okänt fel uppstod');
+          }
+        }
+      );
+    } else if (manualAddress.trim()) {
+      openGoogleMapsDirections(encodeURIComponent(manualAddress.trim()));
+    }
+  };
+
+  const openGoogleMapsDirections = (origin: string) => {
+    const [lng, lat] = selectedLake.geometry.coordinates;
+    const destination = `${lat},${lng}`;
+    const url = `https://www.google.com/maps/dir/${origin}/${destination}`;
+    window.open(url, '_blank');
+  };
+
   return (
     <StyledSidePanel>
-      <Typography variant="h5" component="h2" gutterBottom color="primary">
-        {selectedLake.properties.name}
-      </Typography>
-      <Divider sx={{ mb: 2 }} />
-      <List disablePadding>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Maxdjup" 
-            secondary={selectedLake.properties.maxDepth !== null ? `${selectedLake.properties.maxDepth} m` : 'Okänt'} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Area" 
-            secondary={selectedLake.properties.area !== null && selectedLake.properties.area !== undefined
-              ? `${selectedLake.properties.area.toLocaleString()} ha`
-              : 'Okänd'} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Län" 
-            secondary={selectedLake.properties.county} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Fångade arter" 
-            secondary={renderCaughtSpecies(selectedLake.properties.catchedSpecies || selectedLake.properties.fångadeArter)} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Vanligaste art" 
-            secondary={selectedLake.properties.vanlArt
-              ? `${selectedLake.properties.vanlArt} (${selectedLake.properties.vanlArtWProc}%)`
-              : 'Okänd'} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Näst vanligaste art" 
-            secondary={selectedLake.properties.nästVanlArt
-              ? `${selectedLake.properties.nästVanlArt} (${selectedLake.properties.nästVanlArtWProc}%)`
-              : 'Okänd'} 
-          />
-        </ListItem>
-        <ListItem sx={{ py: 1 }}>
-          <ListItemText 
-            primary="Senaste fiskeår" 
-            secondary={selectedLake.properties.senasteFiskeår || 'Okänt'} 
-          />
-        </ListItem>
-      </List>
+      <ContentSection>
+        <Typography variant="h5" component="h2" gutterBottom color="primary">
+          {selectedLake.properties.name}
+        </Typography>
+        <Divider sx={{ mb: 2 }} />
+        <List disablePadding>
+          <ListItem sx={{ py: 1 }}>
+            <ListItemText 
+              primary="Maxdjup" 
+              secondary={selectedLake.properties.maxDepth !== null ? `${selectedLake.properties.maxDepth} m` : 'Okänt'} 
+            />
+          </ListItem>
+          <ListItem sx={{ py: 1 }}>
+            <ListItemText 
+              primary="Area" 
+              secondary={selectedLake.properties.area !== null && selectedLake.properties.area !== undefined
+                ? `${selectedLake.properties.area.toLocaleString()} ha`
+                : 'Okänd'} 
+            />
+          </ListItem>
+          <ListItem sx={{ py: 1 }}>
+            <ListItemText 
+              primary="Län" 
+              secondary={selectedLake.properties.county} 
+            />
+          </ListItem>
+          <ListItem sx={{ py: 1 }}>
+            <ListItemText 
+              primary="Fångade arter" 
+              secondary={renderCaughtSpecies(selectedLake.properties.catchedSpecies || selectedLake.properties.fångadeArter)} 
+            />
+          </ListItem>
+          <ListItem sx={{ py: 1 }}>
+            <ListItemText 
+              primary="Vanligaste art" 
+              secondary={selectedLake.properties.vanlArt
+                ? `${selectedLake.properties.vanlArt} (${selectedLake.properties.vanlArtWProc}%)`
+                : 'Okänd'} 
+            />
+          </ListItem>
+          <ListItem sx={{ py: 1 }}>
+            <ListItemText 
+              primary="Näst vanligaste art" 
+              secondary={selectedLake.properties.nästVanlArt
+                ? `${selectedLake.properties.nästVanlArt} (${selectedLake.properties.nästVanlArtWProc}%)`
+                : 'Okänd'} 
+            />
+          </ListItem>
+          <ListItem sx={{ py: 1 }}>
+            <ListItemText 
+              primary="Senaste fiskeår" 
+              secondary={selectedLake.properties.senasteFiskeår || 'Okänt'} 
+            />
+          </ListItem>
+        </List>
+      </ContentSection>
+      
+      <DirectionsSection>
+        <Typography variant="subtitle2" gutterBottom color="primary" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <DirectionsIcon fontSize="small" />
+          Vägbeskrivning
+        </Typography>
+        
+        <Stack spacing={2}>
+          <ToggleButtonGroup
+            value={locationType}
+            exclusive
+            onChange={(e, newValue) => newValue && setLocationType(newValue)}
+            size="small"
+            fullWidth
+          >
+            <ToggleButton value="current">
+              <MyLocationIcon sx={{ mr: 1, fontSize: 18 }} />
+              Min position
+            </ToggleButton>
+            <ToggleButton value="manual">
+              <LocationOnIcon sx={{ mr: 1, fontSize: 18 }} />
+              Ange adress
+            </ToggleButton>
+          </ToggleButtonGroup>
+          
+          {locationType === 'manual' && (
+            <TextField
+              size="small"
+              placeholder="Skriv din adress..."
+              value={manualAddress}
+              onChange={(e) => setManualAddress(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleGetDirections();
+                }
+              }}
+              fullWidth
+            />
+          )}
+          
+          {locationError && (
+            <Alert severity="error" sx={{ py: 0.5 }}>
+              {locationError}
+            </Alert>
+          )}
+          
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleGetDirections}
+            disabled={isGettingLocation || (locationType === 'manual' && !manualAddress.trim())}
+            startIcon={isGettingLocation ? <CircularProgress size={16} /> : <DirectionsIcon />}
+            fullWidth
+          >
+            {isGettingLocation ? 'Hämtar position...' : 'Få vägbeskrivning'}
+          </Button>
+        </Stack>
+      </DirectionsSection>
     </StyledSidePanel>
   );
 };

--- a/src/components/__tests__/SidePanel.test.tsx
+++ b/src/components/__tests__/SidePanel.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import SidePanel from '../SidePanel';
 import { GeoJsonFeature } from '../../types/GeoJsonTypes';
 
@@ -40,5 +41,151 @@ describe('SidePanel', () => {
     expect(screen.getByText('Pike (60%)')).toBeInTheDocument();
     expect(screen.getByText('Perch (40%)')).toBeInTheDocument();
     expect(screen.getByText('2023')).toBeInTheDocument();
+  });
+
+  describe('Directions functionality', () => {
+    // Mock window.open
+    const mockWindowOpen = jest.fn();
+    const originalOpen = window.open;
+    
+    beforeEach(() => {
+      window.open = mockWindowOpen;
+      mockWindowOpen.mockClear();
+    });
+    
+    afterEach(() => {
+      window.open = originalOpen;
+    });
+
+    it('displays directions section with toggle buttons', () => {
+      render(<SidePanel selectedLake={mockLake} />);
+      
+      expect(screen.getByText('Vägbeskrivning')).toBeInTheDocument();
+      expect(screen.getByText('Min position')).toBeInTheDocument();
+      expect(screen.getByText('Ange adress')).toBeInTheDocument();
+      expect(screen.getByText('Få vägbeskrivning')).toBeInTheDocument();
+    });
+
+    it('shows address input when manual location is selected', () => {
+      render(<SidePanel selectedLake={mockLake} />);
+      
+      // Initially, address input should not be visible
+      expect(screen.queryByPlaceholderText('Skriv din adress...')).not.toBeInTheDocument();
+      
+      // Click on manual address toggle
+      fireEvent.click(screen.getByText('Ange adress'));
+      
+      // Address input should now be visible
+      expect(screen.getByPlaceholderText('Skriv din adress...')).toBeInTheDocument();
+    });
+
+    it('disables button when manual mode is selected but no address is entered', () => {
+      render(<SidePanel selectedLake={mockLake} />);
+      
+      fireEvent.click(screen.getByText('Ange adress'));
+      
+      const button = screen.getByText('Få vägbeskrivning').closest('button');
+      expect(button).toBeDisabled();
+      
+      // Enter an address
+      const input = screen.getByPlaceholderText('Skriv din adress...');
+      fireEvent.change(input, { target: { value: 'Test Address' } });
+      
+      expect(button).not.toBeDisabled();
+    });
+
+    it('opens Google Maps with manual address', () => {
+      render(<SidePanel selectedLake={mockLake} />);
+      
+      // Switch to manual mode
+      fireEvent.click(screen.getByText('Ange adress'));
+      
+      // Enter address
+      const input = screen.getByPlaceholderText('Skriv din adress...');
+      fireEvent.change(input, { target: { value: 'Stockholm, Sweden' } });
+      
+      // Click get directions
+      fireEvent.click(screen.getByText('Få vägbeskrivning'));
+      
+      // Check that window.open was called with correct URL
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        'https://www.google.com/maps/dir/Stockholm%2C%20Sweden/59.3293,18.0686',
+        '_blank'
+      );
+    });
+
+    it('handles Enter key press in address input', () => {
+      render(<SidePanel selectedLake={mockLake} />);
+      
+      fireEvent.click(screen.getByText('Ange adress'));
+      
+      const input = screen.getByPlaceholderText('Skriv din adress...');
+      fireEvent.change(input, { target: { value: 'Test Address' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      
+      expect(mockWindowOpen).toHaveBeenCalled();
+    });
+
+    it('requests geolocation when using current position', async () => {
+      // Mock geolocation
+      const mockGeolocation = {
+        getCurrentPosition: jest.fn()
+      };
+      Object.defineProperty(navigator, 'geolocation', {
+        value: mockGeolocation,
+        writable: true
+      });
+      
+      render(<SidePanel selectedLake={mockLake} />);
+      
+      fireEvent.click(screen.getByText('Få vägbeskrivning'));
+      
+      expect(mockGeolocation.getCurrentPosition).toHaveBeenCalled();
+      
+      // Simulate successful geolocation
+      const successCallback = mockGeolocation.getCurrentPosition.mock.calls[0][0];
+      act(() => {
+        successCallback({
+          coords: {
+            latitude: 59.3326,
+            longitude: 18.0649
+          }
+        });
+      });
+      
+      await waitFor(() => {
+        expect(mockWindowOpen).toHaveBeenCalledWith(
+          'https://www.google.com/maps/dir/59.3326,18.0649/59.3293,18.0686',
+          '_blank'
+        );
+      });
+    });
+
+    it('shows error when geolocation is denied', async () => {
+      const mockGeolocation = {
+        getCurrentPosition: jest.fn()
+      };
+      Object.defineProperty(navigator, 'geolocation', {
+        value: mockGeolocation,
+        writable: true
+      });
+      
+      render(<SidePanel selectedLake={mockLake} />);
+      
+      fireEvent.click(screen.getByText('Få vägbeskrivning'));
+      
+      // Simulate geolocation error
+      const errorCallback = mockGeolocation.getCurrentPosition.mock.calls[0][1];
+      act(() => {
+        errorCallback({
+          code: 1, // PERMISSION_DENIED
+          PERMISSION_DENIED: 1
+        });
+      });
+      
+      await waitFor(() => {
+        expect(screen.getByText('Åtkomst till plats nekad')).toBeInTheDocument();
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Added driving directions interface at bottom of left side panel
- Users can choose between automatic location or manual address entry
- Opens Google Maps with directions to the selected lake

## Test plan
- [x] Run unit tests (`npm test`)
- [x] Verify directions section appears when a lake is selected
- [x] Test toggle between "My position" and "Enter address"
- [x] Test manual address entry and button enablement
- [x] Verify geolocation request when using current position
- [x] Test error handling for geolocation denial
- [x] Verify Google Maps opens with correct directions URL

🤖 Generated with [Claude Code](https://claude.ai/code)