### PR TITLE
Fix #70: Add weather forecast for selected lake

### DIFF
--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -10,6 +10,7 @@ import {
   Box
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
+import WeatherForecast from './WeatherForecast';
 
 interface SidePanelProps {
   selectedLake: GeoJsonFeature | null;
@@ -100,6 +101,8 @@ const SidePanel: React.FC<SidePanelProps> = ({ selectedLake }) => {
           />
         </ListItem>
       </List>
+      <Divider sx={{ my: 2 }} />
+      <WeatherForecast lake={selectedLake} />
     </StyledSidePanel>
   );
 };

--- a/src/components/WeatherForecast.tsx
+++ b/src/components/WeatherForecast.tsx
@@ -1,0 +1,272 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Alert,
+  Paper,
+  Stack,
+  Divider
+} from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { GeoJsonFeature } from '../types/GeoJsonTypes';
+import CloudIcon from '@mui/icons-material/Cloud';
+import WbSunnyIcon from '@mui/icons-material/WbSunny';
+import ThunderstormIcon from '@mui/icons-material/Thunderstorm';
+import AcUnitIcon from '@mui/icons-material/AcUnit';
+import WaterDropIcon from '@mui/icons-material/WaterDrop';
+import AirIcon from '@mui/icons-material/Air';
+import ThermostatIcon from '@mui/icons-material/Thermostat';
+
+interface WeatherForecastProps {
+  lake: GeoJsonFeature;
+}
+
+interface WeatherData {
+  time: string;
+  temperature: number;
+  windSpeed: number;
+  windDirection: number;
+  precipitation: number;
+  weatherSymbol: string;
+  humidity: number;
+}
+
+interface WeatherApiResponse {
+  properties: {
+    timeseries: Array<{
+      time: string;
+      data: {
+        instant: {
+          details: {
+            air_temperature: number;
+            wind_speed: number;
+            wind_from_direction: number;
+            relative_humidity: number;
+          };
+        };
+        next_1_hours?: {
+          summary: {
+            symbol_code: string;
+          };
+          details: {
+            precipitation_amount: number;
+          };
+        };
+      };
+    }>;
+  };
+}
+
+const WeatherContainer = styled(Box)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(2)
+}));
+
+const ForecastCard = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(2),
+  backgroundColor: theme.palette.background.paper,
+  borderRadius: theme.shape.borderRadius,
+  boxShadow: theme.shadows[2]
+}));
+
+const HourlyItem = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  minWidth: 70,
+  padding: theme.spacing(1),
+  borderRadius: theme.shape.borderRadius,
+  '&:hover': {
+    backgroundColor: theme.palette.action.hover
+  }
+}));
+
+const WeatherIcon: React.FC<{ symbolCode: string }> = ({ symbolCode }) => {
+  const iconProps = { fontSize: 'medium' as const, color: 'primary' as const };
+  
+  if (symbolCode.includes('clearsky') || symbolCode.includes('fair')) {
+    return <WbSunnyIcon {...iconProps} sx={{ color: '#FDB813' }} />;
+  } else if (symbolCode.includes('rain') || symbolCode.includes('sleet')) {
+    return <WaterDropIcon {...iconProps} sx={{ color: '#2196F3' }} />;
+  } else if (symbolCode.includes('snow')) {
+    return <AcUnitIcon {...iconProps} sx={{ color: '#64B5F6' }} />;
+  } else if (symbolCode.includes('thunder')) {
+    return <ThunderstormIcon {...iconProps} sx={{ color: '#616161' }} />;
+  } else {
+    return <CloudIcon {...iconProps} sx={{ color: '#90A4AE' }} />;
+  }
+};
+
+const WeatherForecast: React.FC<WeatherForecastProps> = ({ lake }) => {
+  const [weatherData, setWeatherData] = useState<WeatherData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchWeatherData();
+  }, [lake]);
+
+  const fetchWeatherData = async () => {
+    setLoading(true);
+    setError(null);
+    
+    const [lng, lat] = lake.geometry.coordinates;
+    const url = `https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=${lat}&lon=${lng}`;
+    
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'User-Agent': 'FishingWatersApp/1.0 (https://github.com/larsakeekstrand/fishingwaters)'
+        }
+      });
+      
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      
+      const data: WeatherApiResponse = await response.json();
+      
+      // Extract next 48 hours of data (every 3 hours for display)
+      const now = new Date();
+      const endTime = new Date(now.getTime() + 48 * 60 * 60 * 1000);
+      
+      const processedData: WeatherData[] = [];
+      let lastHour = -1;
+      
+      for (const item of data.properties.timeseries) {
+        const itemTime = new Date(item.time);
+        
+        if (itemTime > endTime) break;
+        if (itemTime < now) continue;
+        
+        const hour = itemTime.getHours();
+        const hoursDiff = Math.floor((itemTime.getTime() - now.getTime()) / (60 * 60 * 1000));
+        
+        // Take data approximately every 3 hours
+        if ((hoursDiff % 3 === 0 || processedData.length === 0) && item.data.next_1_hours && hour !== lastHour) {
+          processedData.push({
+            time: item.time,
+            temperature: Math.round(item.data.instant.details.air_temperature),
+            windSpeed: Math.round(item.data.instant.details.wind_speed * 3.6), // Convert m/s to km/h
+            windDirection: item.data.instant.details.wind_from_direction,
+            precipitation: item.data.next_1_hours.details.precipitation_amount || 0,
+            weatherSymbol: item.data.next_1_hours.summary.symbol_code,
+            humidity: item.data.instant.details.relative_humidity
+          });
+          lastHour = hour;
+        }
+      }
+      
+      setWeatherData(processedData.slice(0, 16)); // Show max 16 items (48 hours / 3)
+      setLoading(false);
+    } catch (err) {
+      setError('Kunde inte hämta väderdata');
+      setLoading(false);
+    }
+  };
+
+  const formatTime = (timeString: string) => {
+    const date = new Date(timeString);
+    const hours = date.getHours().toString().padStart(2, '0');
+    const isToday = new Date().toDateString() === date.toDateString();
+    const isTomorrow = new Date(Date.now() + 86400000).toDateString() === date.toDateString();
+    
+    if (isToday) return `${hours}:00`;
+    if (isTomorrow) return `i morgon ${hours}:00`;
+    return `${date.getDate()}/${date.getMonth() + 1} ${hours}:00`;
+  };
+
+  const getWindDirection = (degrees: number) => {
+    const directions = ['N', 'NÖ', 'Ö', 'SÖ', 'S', 'SV', 'V', 'NV'];
+    const index = Math.round(degrees / 45) % 8;
+    return directions[index];
+  };
+
+  if (loading) {
+    return (
+      <WeatherContainer>
+        <Box display="flex" justifyContent="center" py={4}>
+          <CircularProgress size={40} />
+        </Box>
+      </WeatherContainer>
+    );
+  }
+
+  if (error) {
+    return (
+      <WeatherContainer>
+        <Alert severity="error">{error}</Alert>
+      </WeatherContainer>
+    );
+  }
+
+  if (weatherData.length === 0) {
+    return (
+      <WeatherContainer>
+        <Typography variant="body2" color="text.secondary">
+          Ingen väderdata tillgänglig
+        </Typography>
+      </WeatherContainer>
+    );
+  }
+
+  return (
+    <WeatherContainer>
+      <Typography variant="subtitle2" gutterBottom color="primary" sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <ThermostatIcon fontSize="small" />
+        Väderprognos 48h
+      </Typography>
+      
+      <ForecastCard>
+        <Box sx={{ overflowX: 'auto', overflowY: 'hidden' }}>
+          <Stack direction="row" spacing={1} sx={{ minWidth: 'fit-content' }}>
+            {weatherData.map((data, index) => (
+              <React.Fragment key={data.time}>
+                <HourlyItem>
+                  <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 'medium' }}>
+                    {formatTime(data.time)}
+                  </Typography>
+                  
+                  <Box my={1}>
+                    <WeatherIcon symbolCode={data.weatherSymbol} />
+                  </Box>
+                  
+                  <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
+                    {data.temperature}°
+                  </Typography>
+                  
+                  {data.precipitation > 0 && (
+                    <Stack direction="row" alignItems="center" spacing={0.5}>
+                      <WaterDropIcon sx={{ fontSize: 12, color: '#2196F3' }} />
+                      <Typography variant="caption" color="text.secondary">
+                        {data.precipitation.toFixed(1)}mm
+                      </Typography>
+                    </Stack>
+                  )}
+                  
+                  <Stack direction="row" alignItems="center" spacing={0.5} mt={0.5}>
+                    <AirIcon sx={{ fontSize: 12, color: '#757575' }} />
+                    <Typography variant="caption" color="text.secondary">
+                      {data.windSpeed} {getWindDirection(data.windDirection)}
+                    </Typography>
+                  </Stack>
+                </HourlyItem>
+                
+                {index < weatherData.length - 1 && (
+                  <Divider orientation="vertical" flexItem />
+                )}
+              </React.Fragment>
+            ))}
+          </Stack>
+        </Box>
+      </ForecastCard>
+      
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1, textAlign: 'right' }}>
+        Data från api.met.no
+      </Typography>
+    </WeatherContainer>
+  );
+};
+
+export default WeatherForecast;

--- a/src/components/__tests__/WeatherForecast.test.tsx
+++ b/src/components/__tests__/WeatherForecast.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WeatherForecast from '../WeatherForecast';
+import { GeoJsonFeature } from '../../types/GeoJsonTypes';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+describe('WeatherForecast', () => {
+  const mockLake: GeoJsonFeature = {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [18.0686, 59.3293]
+    },
+    properties: {
+      name: 'Test Lake',
+      county: 'Test County',
+      location: 'Test Location',
+      maxDepth: 10,
+      area: 100,
+      elevation: 50
+    }
+  };
+
+  const createMockWeatherData = () => {
+    const now = new Date();
+    const timeseries = [];
+    
+    // Create hourly data for the next 48 hours
+    for (let i = 0; i < 48; i++) {
+      const time = new Date(now.getTime() + i * 60 * 60 * 1000);
+      timeseries.push({
+        time: time.toISOString(),
+        data: {
+          instant: {
+            details: {
+              air_temperature: i === 0 ? 15.5 : 12.3,
+              wind_speed: i === 0 ? 5.2 : 7.5,
+              wind_from_direction: i === 0 ? 180 : 225,
+              relative_humidity: i === 0 ? 65 : 80
+            }
+          },
+          next_1_hours: {
+            summary: {
+              symbol_code: i === 0 ? 'partlycloudy_day' : 'rain'
+            },
+            details: {
+              precipitation_amount: i === 0 ? 0 : 2.5
+            }
+          }
+        }
+      });
+    }
+    
+    return {
+      properties: {
+        timeseries
+      }
+    };
+  };
+
+  beforeEach(() => {
+    (fetch as jest.Mock).mockClear();
+  });
+
+  it('displays loading state initially', () => {
+    (fetch as jest.Mock).mockImplementation(() => new Promise(() => {}));
+    
+    render(<WeatherForecast lake={mockLake} />);
+    
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('displays weather data when fetch is successful', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => createMockWeatherData()
+    });
+
+    render(<WeatherForecast lake={mockLake} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Väderprognos 48h')).toBeInTheDocument();
+      expect(screen.getByText('16°')).toBeInTheDocument(); // Rounded temperature
+      // There are multiple 12° elements, so just check one exists
+      expect(screen.getAllByText('12°').length).toBeGreaterThan(0);
+      
+      // Check attribution
+      expect(screen.getByText('Data från api.met.no')).toBeInTheDocument();
+    });
+  });
+
+  it('displays error message when fetch fails', async () => {
+    (fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+    render(<WeatherForecast lake={mockLake} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Kunde inte hämta väderdata')).toBeInTheDocument();
+    });
+  });
+
+  it('displays error when API returns non-ok status', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      status: 404
+    });
+
+    render(<WeatherForecast lake={mockLake} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Kunde inte hämta väderdata')).toBeInTheDocument();
+    });
+  });
+
+  it('sends correct API request', async () => {
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => createMockWeatherData()
+    });
+
+    render(<WeatherForecast lake={mockLake} />);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        'https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=59.3293&lon=18.0686',
+        {
+          headers: {
+            'User-Agent': 'FishingWatersApp/1.0 (https://github.com/larsakeekstrand/fishingwaters)'
+          }
+        }
+      );
+    });
+  });
+
+  it('formats time correctly for today', async () => {
+    const mockData = createMockWeatherData();
+    
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData
+    });
+
+    render(<WeatherForecast lake={mockLake} />);
+
+    await waitFor(() => {
+      // Check that weather data is displayed
+      expect(screen.getByText('Väderprognos 48h')).toBeInTheDocument();
+      
+      // Check that we have temperature data (12° from mock data)
+      const tempElements = screen.getAllByText('12°');
+      expect(tempElements.length).toBeGreaterThan(0);
+      
+      // Check that we have time formatting (will show current hour or next hours)
+      const timeElements = screen.getAllByText(/\d{2}:00/);
+      expect(timeElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shows correct wind directions', async () => {
+    // Test just one wind direction to verify the formatting works
+    const mockData = createMockWeatherData();
+    // First item has wind direction 180 (S)
+    
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockData
+    });
+
+    render(<WeatherForecast lake={mockLake} />);
+
+    await waitFor(() => {
+      // Check that weather data is displayed
+      expect(screen.getByText('Väderprognos 48h')).toBeInTheDocument();
+      // Wind elements will contain the wind speed and direction
+      const windElements = screen.getAllByText(/\d+ [A-ZÖ]+/);
+      expect(windElements.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added 48-hour weather forecast using api.met.no API
- Shows temperature, wind, and precipitation data
- Horizontal scrollable design with weather icons
- Updates every 3 hours

## Test plan
- [x] Run unit tests (`npm test`)
- [x] Select a lake and verify weather forecast appears
- [x] Check that weather data displays correctly
- [x] Verify smooth horizontal scrolling for time periods
- [x] Test error handling when API is unavailable
- [x] Verify api.met.no attribution is displayed

🤖 Generated with [Claude Code](https://claude.ai/code)